### PR TITLE
Add back to top button in live preview panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,7 +636,7 @@
                 .md
               </button>
             </div>
-            <button class="pbtn back-to-top" id="backToTop" onclick="scrollToTop()">
+            <button class="pbtn back-to-top" id="backToTop" onclick="scrollToTop()" aria-label="Back to top">
               <svg
                 width="11"
                 height="11"

--- a/index.html
+++ b/index.html
@@ -636,6 +636,19 @@
                 .md
               </button>
             </div>
+            <button class="pbtn back-to-top" id="backToTop" onclick="scrollToTop()">
+              <svg
+                width="11"
+                height="11"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <polyline points="18 15 12 9 6 15" />
+              </svg>
+              Top
+            </button>
           </div>
           <div class="preview-body" id="previewBody">
             <div class="empty-preview">

--- a/readmeforge.css
+++ b/readmeforge.css
@@ -508,6 +508,7 @@ body::after {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 /* ── SIDEBAR ── */
@@ -1006,6 +1007,10 @@ select option {
   border-color: var(--accent);
   color: var(--accent);
   transform: translateY(-1px);
+}
+.back-to-top:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .preview-body {
   flex: 1;

--- a/readmeforge.css
+++ b/readmeforge.css
@@ -988,6 +988,25 @@ select option {
   background: rgba(16, 185, 129, 0.2);
   color: #10b981;
 }
+.back-to-top {
+  position: absolute;
+  bottom: 16px;
+  right: 20px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(10px);
+  transition: all 0.3s ease;
+}
+.back-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+.back-to-top:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  transform: translateY(-1px);
+}
 .preview-body {
   flex: 1;
   overflow-y: auto;

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -206,6 +206,10 @@
     setupDropZone();
     updateSectionCount();
     scheduleRender();
+    var previewBody = document.getElementById("previewBody");
+    if (previewBody) {
+      previewBody.addEventListener("scroll", updateBackToTopButton);
+    }
   }
 
   // ── Build UI components ───────────────────────────────────────
@@ -1065,6 +1069,30 @@
     toast("✓ README.md downloaded!");
   }
   window.downloadMd = downloadMd;
+
+  function scrollToTop() {
+    var previewBody = document.getElementById("previewBody");
+    if (previewBody) {
+      previewBody.scrollTo({
+        top: 0,
+        behavior: "smooth"
+      });
+    }
+  }
+  window.scrollToTop = scrollToTop;
+
+  function updateBackToTopButton() {
+    var backToTopBtn = document.getElementById("backToTop");
+    var previewBody = document.getElementById("previewBody");
+    if (backToTopBtn && previewBody) {
+      if (previewBody.scrollTop > 300) {
+        backToTopBtn.classList.add("visible");
+      } else {
+        backToTopBtn.classList.remove("visible");
+      }
+    }
+  }
+  window.updateBackToTopButton = updateBackToTopButton;
 
   function resetAll() {
     document


### PR DESCRIPTION
## Summary
Adds a "Back to Top" button to the live preview panel that appears after scrolling down and smoothly returns the user to the top.

## Changes Made

### HTML (`index.html`)
- Added a button element (`#backToTop`) inside the preview panel container
- Includes an SVG arrow icon and "Top" text
- Uses `onclick="scrollToTop()"` for the click handler

### CSS (`readmeforge.css`)
- Added `.back-to-top` class with:
  - `position: absolute` for bottom-right positioning
  - `opacity: 0` and `visibility: hidden` for initial state
  - `transform: translateY(10px)` for a subtle slide-in animation
  - `.visible` class to show the button (opacity 1, visible, translateY 0)
  - Hover and focus states for accessibility
- Added `position: relative` to the preview panel container so the button is positioned relative to it

### JavaScript (`readmeforge.js`)
- Added scroll event listener to `previewBody` that calls `updateBackToTopButton()`
- `updateBackToTopButton()` shows the button when `scrollTop > 300px`, hides it otherwise
- `scrollToTop()` uses `previewBody.scrollTo({ top: 0, behavior: "smooth" })` for smooth scrolling

## Verification
- ✅ Button appears after scrolling down 300px in the preview panel
- ✅ Clicking the button smoothly scrolls to the top
- ✅ Button is positioned at bottom-right and doesn't block content
- ✅ Button disappears when already at the top
- ✅ No console errors

## Limitations
- Scroll threshold is hardcoded at 300px (could be made configurable)
- Button is always in the DOM, just hidden via CSS (no DOM manipulation on show/hide)