### PR TITLE
feat: add Contact section to Readme output

### DIFF
--- a/readmeforge.js
+++ b/readmeforge.js
@@ -810,7 +810,23 @@
         (authorGh || ghUser) +
         ")\n";
     }
+    // 12. Contact Section
+var hasContact = authorEmail || authorLi || authorWeb;
 
+if (hasContact) {
+  md += "\n## 📬 Contact\n\n";
+
+if (authorEmail)
+  md += "- 📧 Email: [" + authorEmail + "](mailto:" + authorEmail + ")\n";
+
+if (authorLi)
+  md += "- 💼 LinkedIn: [" + displayName + "](" + authorLi + ")\n";
+
+if (authorWeb)
+  md += "- 🌐 Website: [" + authorWeb + "](" + authorWeb + ")\n";
+
+ md += "\n---\n\n";
+}
     return md;
   }
 


### PR DESCRIPTION
Added a Contact section with support for email, LinkedIn, and website links.

- Dynamically renders only when fields are provided
- Includes email, LinkedIn, and website
- Clean markdown formatting