### PR TITLE
feat: add print preview button above preview panel, closes #24

### DIFF
--- a/index.html
+++ b/index.html
@@ -457,6 +457,14 @@ placeholder="SECRET_KEY=your_secret&#10;DATABASE_URL=sqlite:///db.sqlite3&#10;DE
               </svg>
               .md
             </button>
+            <button class="pbtn" id="printPreviewBtn" onclick="printPreview()">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="6 9 6 2 18 2 18 9" />
+                <path d="M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2" />
+                <rect x="6" y="14" width="12" height="8" />
+              </svg>
+              Print Preview
+            </button>
           </div>
         </div>
         <!-- ── QUALITY SCORE PANEL ── -->

--- a/index.html
+++ b/index.html
@@ -457,7 +457,7 @@ placeholder="SECRET_KEY=your_secret&#10;DATABASE_URL=sqlite:///db.sqlite3&#10;DE
               </svg>
               .md
             </button>
-            <button class="pbtn" id="printPreviewBtn" onclick="printPreview()">
+            <button class="pbtn print" id="printPreviewBtn" onclick="printPreview()">
               <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="6 9 6 2 18 2 18 9" />
                 <path d="M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2" />

--- a/readmeforge.css
+++ b/readmeforge.css
@@ -1805,6 +1805,7 @@ select option {
   padding: 24px;
   background: var(--bg);
 }
+.spinner {
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
 }
@@ -2079,4 +2080,117 @@ select option {
 
 .autosave-status.visible {
   opacity: 1;
+}
+/* ── PRINT MEDIA STYLES ── */
+@media print {
+
+  /* Hide everything except the preview panel */
+  .top-nav {
+    display: none !important;
+  }
+
+  .hero-content {
+    display: none !important;
+  }
+
+  .header {
+    display: none !important;
+  }
+
+  .sidebar {
+    display: none !important;
+  }
+
+  .editor {
+    display: none !important;
+  }
+
+  /* Show the preview panel full width */
+  .preview {
+    display: block !important;
+    width: 100% !important;
+    height: auto !important;
+    overflow: visible !important;
+    position: static !important;
+    border: none !important;
+    background: white !important;
+  }
+
+  /* Hide the preview header (tabs + buttons) */
+  .preview-header {
+    display: none !important;
+  }
+
+  /* Hide the quality score panel */
+  .quality-panel {
+    display: none !important;
+  }
+
+  /* Make the preview body fully visible */
+  .preview-body {
+    overflow: visible !important;
+    padding: 0 !important;
+    background: white !important;
+    color: black !important;
+  }
+
+  /* Clean up the rendered markdown */
+  .gh-preview {
+    background: white !important;
+    color: black !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    max-width: 100% !important;
+    padding: 0 !important;
+  }
+
+  pre {
+    border: 1px solid #e2e8f0 !important;
+    background: #f8fafc !important;
+    color: black !important;
+  }
+
+  code {
+    border: 1px solid #e2e8f0 !important;
+    background: #f8fafc !important;
+    color: black !important;
+  }
+
+  pre {
+    page-break-inside: avoid;
+  }
+
+  blockquote {
+    page-break-inside: avoid;
+  }
+
+  table {
+    page-break-inside: avoid;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+
+  a {
+    text-decoration: none !important;
+    color: black !important;
+  }
+  /* Hide the hero/landing section */
+  .hero-content {
+    display: none !important;
+  }
+
+  /* Hide toast notifications */
+  .toast {
+    display: none !important;
+  }
+  /* Hide hero section and scroll button */
+  .hero-wrapper {
+    display: none !important;
+  }
+
+  .scroll-action {
+    display: none !important;
+  }
 }

--- a/readmeforge.css
+++ b/readmeforge.css
@@ -1021,6 +1021,7 @@ select option {
 .preview-actions {
   display: flex;
   gap: 8px;
+  margin-left: 8px;
 }
 
 .pbtn {

--- a/readmeforge.css
+++ b/readmeforge.css
@@ -1024,7 +1024,7 @@ select option {
 }
 
 .pbtn {
-  padding: 8px 14px;
+  padding: 8px 10px;
   border-radius: 8px;
   font-size: 12px;
   font-weight: 600;
@@ -1055,6 +1055,18 @@ select option {
 .pbtn.green:hover {
   background: rgba(16, 185, 129, 0.2);
   color: #10b981;
+}
+
+.pbtn.print {
+  background: rgba(129, 140, 248, 0.08);
+  border-color: rgba(129, 140, 248, 0.3);
+  color: var(--accent2);
+}
+
+.pbtn.print:hover {
+  background: rgba(129, 140, 248, 0.18);
+  color: var(--accent2);
+  border-color: var(--accent2);
 }
 
 .preview-body {

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -1868,7 +1868,24 @@
     toast("✓ README.md downloaded!");
   }
   window.downloadMd = downloadMd;  // Expose globally for HTML
-
+  
+  /**
+   * Opens the browser print dialog showing only the preview panel content.
+   * Hides the editor panel and all UI controls using CSS print media queries.
+   * Works across Chrome, Firefox, and Edge.
+   *
+   * @function printPreview
+   * @returns {void}
+   */
+  function printPreview() {
+    if (!currentMd) {
+      toast("Nothing to print yet!");
+      return;
+    }
+    toast("Opening print preview...");
+    window.print();
+  }
+  window.printPreview = printPreview;  // Expose globally for HTML
 
   /**
    * Resets all form fields and application state to defaults.


### PR DESCRIPTION
Submitted as part of NSoC'26 (Nexus Spring of Code 2026)

Summary
Adds a Print Preview button above the preview panel that opens the browser's native print dialog showing only the rendered README content.

Changes
- Added Print Preview button in 'preview-actions' in 'index.html'
- Added 'printPreview()' function in 'readmeforge.js'
- Added '@media print' CSS rules in 'readmeforge.css' to hide all UI (editor, sidebar, header, hero section, toast) and show only the preview content

Acceptance Criteria
- Print Preview button is visible above the preview panel
- Clicking it opens the browser print dialog
- Only the preview content is visible in print mode
- Editor and UI controls are hidden in print mode
- Output looks clean and readable when printed
- No console errors

Closes #24