### PR TITLE
Added Zoom in zoom out

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,6 +445,12 @@ placeholder="SECRET_KEY=your_secret&#10;DATABASE_URL=sqlite:///db.sqlite3&#10;DE
             </button>
           </div>
           <div class="preview-actions">
+            <div class="preview-zoom-controls">
+              <button class="pbtn" id="zoomOutBtn" onclick="zoomOut()" title="Zoom out (Ctrl/Cmd + -)">−</button>
+              <span class="zoom-indicator" id="zoomLevel">100%</span>
+              <button class="pbtn" id="zoomInBtn" onclick="zoomIn()" title="Zoom in (Ctrl/Cmd + +)">+</button>
+              <button class="pbtn" onclick="resetPreviewZoom()" title="Reset zoom (Ctrl/Cmd + 0)">Reset</button>
+            </div>
             <button class="pbtn green" onclick="copyMarkdown()">
               <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <rect x="9" y="9" width="13" height="13" rx="2" />

--- a/readmeforge.css
+++ b/readmeforge.css
@@ -1098,6 +1098,25 @@ select option {
   gap: 8px;
 }
 
+.preview-zoom-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.zoom-indicator {
+  min-width: 56px;
+  text-align: center;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--muted2);
+  background: var(--surface);
+  border: 1px solid var(--border2);
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+
 .pbtn {
   padding: 8px 14px;
   border-radius: 8px;
@@ -1132,11 +1151,25 @@ select option {
   color: #10b981;
 }
 
+.pbtn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
 .preview-body {
+  --preview-zoom: 1;
   flex: 1;
-  overflow-y: auto;
+  overflow: auto;
   padding: 24px;
   min-height: 0;
+}
+
+.preview-zoom-wrap {
+  width: calc(100% / var(--preview-zoom));
+  transform: scale(var(--preview-zoom));
+  transform-origin: top left;
+  transition: transform 0.2s ease;
 }
 
 /* GitHub-style rendered preview */
@@ -1821,10 +1854,16 @@ body.light-mode .gh-preview {
   .preview-actions {
     width: 100%;
     justify-content: space-between;
+    flex-wrap: wrap;
   }
 
   .preview-actions .pbtn {
     flex: 1;
+    justify-content: center;
+  }
+
+  .preview-zoom-controls {
+    width: 100%;
     justify-content: center;
   }
 }
@@ -1885,9 +1924,6 @@ body.light-mode .gh-preview {
   overflow-y: auto;
   padding: 24px;
   background: var(--bg);
-}
-  border-radius: 50%;
-  animation: spin 0.7s linear infinite;
 }
 
 @keyframes spin {
@@ -2134,6 +2170,11 @@ body.light-mode .gh-preview {
   .preview-actions {
     flex-direction: column;
     width: 100%;
+  }
+
+  .preview-zoom-controls {
+    width: 100%;
+    justify-content: center;
   }
 
   .preview-actions .pbtn {

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -51,6 +51,12 @@
   var renderTimer = null;
   var saveTimer = null;
   var autoSaveTimer = null;
+  var zoomSaveTimer = null;
+
+  // Preview zoom state (25% -> 200% in fixed steps)
+  var PREVIEW_ZOOM_KEY = "readmeforge-preview-zoom";
+  var ZOOM_LEVELS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2];
+  var currentZoom = 1;
 
   // ── localStorage Auto-Save ────────────────────────────────────
   var STORAGE_KEY = "readmeforge-data";
@@ -144,6 +150,111 @@
     toast("✓ Saved data cleared!");
   }
   window.clearSavedData = clearSavedData;
+
+  function getNearestZoom(level) {
+    return ZOOM_LEVELS.reduce(function (closest, candidate) {
+      return Math.abs(candidate - level) < Math.abs(closest - level)
+        ? candidate
+        : closest;
+    }, ZOOM_LEVELS[0]);
+  }
+
+  function savePreviewZoom() {
+    try {
+      localStorage.setItem(PREVIEW_ZOOM_KEY, String(currentZoom));
+    } catch (e) {
+      console.error("Failed to save preview zoom:", e);
+    }
+  }
+
+  function scheduleZoomSave() {
+    clearTimeout(zoomSaveTimer);
+    zoomSaveTimer = setTimeout(savePreviewZoom, 120);
+  }
+
+  function loadPreviewZoom() {
+    try {
+      var raw = localStorage.getItem(PREVIEW_ZOOM_KEY);
+      if (!raw) return;
+      var parsed = parseFloat(raw);
+      if (!isNaN(parsed)) currentZoom = getNearestZoom(parsed);
+    } catch (e) {
+      console.error("Failed to load preview zoom:", e);
+    }
+  }
+
+  function applyPreviewZoom() {
+    var previewBody = document.getElementById("previewBody");
+    var zoomLevel = document.getElementById("zoomLevel");
+    var zoomOutBtn = document.getElementById("zoomOutBtn");
+    var zoomInBtn = document.getElementById("zoomInBtn");
+
+    if (previewBody) {
+      previewBody.style.setProperty("--preview-zoom", String(currentZoom));
+    }
+
+    if (zoomLevel) {
+      zoomLevel.textContent = Math.round(currentZoom * 100) + "%";
+    }
+
+    if (zoomOutBtn) zoomOutBtn.disabled = currentZoom <= ZOOM_LEVELS[0];
+    if (zoomInBtn) zoomInBtn.disabled = currentZoom >= ZOOM_LEVELS[ZOOM_LEVELS.length - 1];
+  }
+
+  function setZoom(level, persist) {
+    var next = getNearestZoom(level);
+    if (next === currentZoom) {
+      applyPreviewZoom();
+      return;
+    }
+    currentZoom = next;
+    applyPreviewZoom();
+    if (persist !== false) scheduleZoomSave();
+  }
+
+  function zoomIn() {
+    var next = ZOOM_LEVELS.find(function (level) {
+      return level > currentZoom;
+    });
+    if (typeof next === "number") setZoom(next);
+  }
+  window.zoomIn = zoomIn;
+
+  function zoomOut() {
+    var next = ZOOM_LEVELS.slice().reverse().find(function (level) {
+      return level < currentZoom;
+    });
+    if (typeof next === "number") setZoom(next);
+  }
+  window.zoomOut = zoomOut;
+
+  function resetPreviewZoom() {
+    setZoom(1);
+  }
+  window.resetPreviewZoom = resetPreviewZoom;
+
+  function setupZoomShortcuts() {
+    document.addEventListener("keydown", function (event) {
+      if (!(event.ctrlKey || event.metaKey)) return;
+
+      if (event.key === "+" || event.key === "=") {
+        event.preventDefault();
+        zoomIn();
+        return;
+      }
+
+      if (event.key === "-" || event.key === "_") {
+        event.preventDefault();
+        zoomOut();
+        return;
+      }
+
+      if (event.key === "0") {
+        event.preventDefault();
+        resetPreviewZoom();
+      }
+    });
+  }
 
   // Query inputs used by the word count feature on text areas.
   const inputs = document.querySelectorAll(".textInput");
@@ -367,6 +478,7 @@
    */
   function init() {
     var hasData = loadFromLocalStorage();
+    loadPreviewZoom();
     buildSectionToggles();
     buildTechPicker();
     if (hasData) {
@@ -386,6 +498,8 @@
       });
       updateStructurePreview();
     }
+    applyPreviewZoom();
+    setupZoomShortcuts();
     scheduleRender();
   }
 
@@ -1442,7 +1556,8 @@
     // Show empty state if no content
     if (!currentMd.trim()) {
       body.innerHTML =
-        '<div class="empty-preview"><div class="icon">📄</div><h3>Live preview appears here</h3><p>Start filling in the editor →</p></div>';
+        '<div class="preview-zoom-wrap"><div class="empty-preview"><div class="icon">📄</div><h3>Live preview appears here</h3><p>Start filling in the editor →</p></div></div>';
+      applyPreviewZoom();
       updateQualityPanel({ score: 0, suggestions: [] });
       return;
     }
@@ -1451,11 +1566,12 @@
     if (currentTab === "rendered") {
       // Display as formatted HTML (GitHub-style preview)
       body.innerHTML =
-        '<div class="gh-preview">' + md2html(currentMd) + "</div>";
+        '<div class="preview-zoom-wrap"><div class="gh-preview">' + md2html(currentMd) + "</div></div>";
     } else {
       // Display raw markdown (escaped for viewing)
-      body.innerHTML = '<div class="raw-view">' + esc(currentMd) + "</div>";
+      body.innerHTML = '<div class="preview-zoom-wrap"><div class="raw-view">' + esc(currentMd) + "</div></div>";
     }
+    applyPreviewZoom();
     updateQualityPanel(calculateQuality());
   }
 


### PR DESCRIPTION

What I changed

1. Added zoom controls in preview header actions
- Added `-`, `% indicator`, `+`, and `Reset` above the preview panel actions in index.html.

2. Added zoom UI styling and smooth scaling
- Added zoom control layout + indicator styles in readmeforge.css.
- Added disabled button state in readmeforge.css.
- Added scalable preview wrapper with smooth transition and zoom variable in readmeforge.css.
- Added responsive handling for zoom controls in readmeforge.css and readmeforge.css.

3. Added zoom logic, persistence, and shortcuts
- Added zoom state and allowed levels `25%, 50%, 75%, 100%, 125%, 150%, 200%` in readmeforge.js.
- Added localStorage save/load for zoom in readmeforge.js and readmeforge.js.
- Added `zoomIn`, `zoomOut`, `resetPreviewZoom`, and `setZoom` in readmeforge.js.
- Added keyboard shortcuts:
  - Ctrl/Cmd + `+` zoom in
  - Ctrl/Cmd + `-` zoom out
  - Ctrl/Cmd + `0` reset
  in readmeforge.js.
- Applied zoom during render by wrapping preview content and updating zoom after each render in readmeforge.js.

4. Reliability fix
- Removed one malformed stray CSS fragment that caused parser errors in readmeforge.css.

Acceptance criteria mapping

- Zoom in increases preview scale: done.
- Zoom out decreases preview scale: done.
- Zoom percentage indicator visible: done.
- Reset returns to 100%: done.
- Zoom preference saved in localStorage: done.
- No new JS errors from this feature: confirmed by diagnostics on readmeforge.js.

closes #19