### PR TITLE
[NSoC'26] Add custom section builder for flexible README creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,13 +147,18 @@
         </div>
 
         <!-- Section Toggles -->
-        <div class="sidebar-section" style="flex: 1">
-          <div class="sidebar-label">Sections</div>
-          <div class="section-toggles" id="sectionToggles">
-            <!-- populated by JS -->
-          </div>
-        </div>
-      </aside>
+<div class="sidebar-section" style="flex: 1">
+  <div class="sidebar-label">Sections</div>
+
+<button id="addCustomSectionBtn" style="margin-bottom:12px; width:100%; padding:10px;">
+  + Add Custom Section
+</button>
+
+<div class="section-toggles" id="sectionToggles">
+  <!-- populated by JS -->
+</div>
+
+</div>
 
       <!-- ── EDITOR ── -->
       <div class="editor">

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -1502,6 +1502,19 @@ document.getElementById("addCustomSectionBtn").addEventListener("click", functio
   });
 
   scheduleRender();
+  setTimeout(function () {
+  var headings = document.getElementsByTagName("h2");
+
+  for (var i = 0; i < headings.length; i++) {
+    if (headings[i].textContent.indexOf("Custom Sections") !== -1) {
+      headings[i].scrollIntoView({
+        behavior: "smooth",
+        block: "start"
+      });
+      break;
+    }
+  }
+}, 500);
 });
   // ── MARKDOWN UTILITIES ────────────────────────────────────────
   var BADGE_COLORS = {

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -47,6 +47,7 @@
   var currentTab = "rendered";
   // screenshots stores image uploads for the Screenshots section.
   var screenshots = [];
+  var customSections = [];
   // renderTimer is used for debounced preview rendering.
   var renderTimer = null;
   var saveTimer = null;
@@ -1185,7 +1186,17 @@
         (authorGh || ghUser) +
         ")\n";
     }
+    // Custom Sections
+if (customSections.length > 0) {
+  md += "## 🧩 Custom Sections\n\n";
 
+  customSections.forEach(function (sec) {
+    md += "### " + sec.title + "\n\n";
+    md += sec.content + "\n\n";
+  });
+
+  md += "---\n\n";
+}
     return md;
   }
 
@@ -1477,7 +1488,21 @@
     render();  // Re-render preview for selected tab
   }
   window.setTab = setTab;  // Expose globally for HTML onclick handlers
+ // ADD CUSTOM SECTION
+document.getElementById("addCustomSectionBtn").addEventListener("click", function () {
 
+  var title = prompt("Enter section title:");
+  var content = prompt("Enter section content:");
+
+  if (!title || !content) return;
+
+  customSections.push({
+    title: title,
+    content: content
+  });
+
+  scheduleRender();
+});
   // ── MARKDOWN UTILITIES ────────────────────────────────────────
   var BADGE_COLORS = {
     brightgreen: "#22c55e",
@@ -2043,3 +2068,13 @@
 
   init();
 })();
+document.getElementById("addCustomSectionBtn").addEventListener("click", function () {
+    var title = prompt("Enter section title");
+    var content = prompt("Enter section content");
+
+    if (!title || !content) return;
+
+    customSections.push({ title: title, content: content });
+
+    alert("Custom section added!");
+});


### PR DESCRIPTION
This PR introduces a custom section builder to make README creation more flexible.

With this feature, users can add their own sections by providing a title and content. 
The custom sections are instantly reflected in the live preview and are also included 
in the generated Markdown output.

Multiple sections can be added, allowing users to fully customize their README 
based on their project needs.

This enhancement improves usability and gives users more control beyond the 
predefined sections.