### PR TITLE
fix: copy button fails in Firefox due to clipboard API permission (#14)

### DIFF
--- a/readmeforge.js
+++ b/readmeforge.js
@@ -1715,36 +1715,53 @@
       toast("Generate content first!");
       return;
     }
-    
-    // Try modern Clipboard API first
+
+    // Try modern Clipboard API first (works in Chrome, Edge, Safari)
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard
         .writeText(currentMd)
         .then(function () {
           toast("✓ Copied to clipboard!");
         })
-        .catch(fbCopy);  // Fall back on error
+        .catch(function () {
+          // Firefox may deny clipboard permission without user gesture
+          // Fall back to execCommand which works with user gesture context
+          fbCopy();
+        });
     } else {
-      // Fall back to older method
+      // Fall back to older method for browsers without Clipboard API
       fbCopy();
     }
-    
-    // Fallback copy method for older browsers
+
+    // Fallback copy method using execCommand (broad browser support)
     function fbCopy() {
-      // Create temporary textarea (off-screen)
+      // Create temporary textarea (off-screen but in DOM)
       var ta = document.createElement("textarea");
       ta.value = currentMd;
-      ta.style.cssText = "position:absolute;left:-9999px";
+      ta.style.cssText = "position:fixed;left:-9999px;top:0;opacity:0;";
+      ta.setAttribute("aria-hidden", "true");
       document.body.appendChild(ta);
-      ta.select();  // Select all text
+
+      // Select the text content
+      ta.focus();
+      ta.select();
+      ta.setSelectionRange(0, currentMd.length);
+
       try {
-        document.execCommand("copy");  // Copy to clipboard
-        toast("✓ Copied!");
+        // Execute copy command within user gesture context
+        var success = document.execCommand("copy");
+        if (success) {
+          toast("✓ Copied to clipboard!");
+        } else {
+          toast("Copy failed. Please copy manually (Ctrl+C / Cmd+C).");
+        }
       } catch (e) {
-        toast("Copy failed");
+        toast("Copy failed. Please copy manually (Ctrl+C / Cmd+C).");
+      } finally {
+        document.body.removeChild(ta);  // Clean up
       }
-      document.body.removeChild(ta);  // Clean up
     }
+  }
   }
   window.copyMarkdown = copyMarkdown;  // Expose globally for HTML
 


### PR DESCRIPTION
## Bug Description

The "Copy Markdown" button fails silently in Firefox. The `navigator.clipboard.writeText()` API requires a direct user gesture context in Firefox, and when it fails, the error handling didn't properly fall back to `document.execCommand('copy')`.

## Steps to Reproduce

1. Open ReadmeForge in Firefox
2. Generate any README content
3. Click the "Copy Markdown" button
4. Nothing is copied to clipboard (silent failure)

## Root Cause

- `.catch(fbCopy)` passed the function reference but Firefox's permission error wasn't being caught properly
- The fallback `fbCopy()` didn't call `ta.focus()` before selecting, which Firefox requires
- No user-facing error message when copy fails

## Fix

1. **Proper error handling**: Changed `.catch(fbCopy)` to `.catch(function() { fbCopy(); })` to ensure Firefox clipboard denial triggers the fallback
2. **Focus before select**: Added `ta.focus()` and `ta.setSelectionRange()` for Firefox compatibility
3. **Better positioning**: Changed `position:absolute` to `position:fixed` for more reliable off-screen placement
4. **User feedback**: Added clear error message when execCommand returns false
5. **Proper cleanup**: Wrapped in `try/catch/finally` to ensure textarea is always removed

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Fixes #14 
- [x] Follows contribution guidelines
- [x] Minimal, focused change

---

Closes #14