### PR TITLE
feat: add collapsible sections and restore saved section state

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,7 @@
             <div class="es-header">
               <div class="es-num">1</div>
               <div class="es-title">Project Title & Badges</div>
+              <button class="collapse-btn" onclick="toggleSection('sec-title')"  aria-label="Toggle section">&#9660;</button>
             </div>
             <div class="es-body">
               <div class="two-col">
@@ -199,6 +200,7 @@
             <div class="es-header">
               <div class="es-num">2</div>
               <div class="es-title">Description</div>
+              <button class="collapse-btn" onclick="toggleSection('sec-description')"  aria-label="Toggle section">&#9660;</button>
             </div>
             <div class="es-body">
               <div>
@@ -220,6 +222,7 @@
             <div class="es-header">
               <div class="es-num">3</div>
               <div class="es-title">Features</div>
+              <button class="collapse-btn" onclick="toggleSection('sec-features')"  aria-label="Toggle section">&#9660;</button>
             </div>
             <div class="es-body">
               <div>
@@ -239,6 +242,7 @@
               <div class="es-num">4</div>
               <div class="es-title">Tech Stack</div>
               <span class="es-badge" id="techCount" style="display: none">0 selected</span>
+              <button class="collapse-btn" onclick="toggleSection('sec-techstack')"  aria-label="Toggle section">&#9660;</button>
             </div>
             <div class="es-body">
               <div>
@@ -259,6 +263,7 @@
             <div class="es-header">
               <div class="es-num">5</div>
               <div class="es-title">Installation</div>
+              <button class="collapse-btn" onclick="toggleSection('sec-installation')"  aria-label="Toggle section">&#9660;</button>
             </div>
             <div class="es-body">
               <div>
@@ -291,6 +296,7 @@ placeholder="SECRET_KEY=your_secret&#10;DATABASE_URL=sqlite:///db.sqlite3&#10;DE
             <div class="es-header">
               <div class="es-num">7</div>
               <div class="es-title">Project Structure Visualizer</div>
+              <button class="collapse-btn" onclick="toggleSection('sec-structure')"  aria-label="Toggle section">&#9660;</button>
             </div>
             <div class="es-body">
               <div>
@@ -313,6 +319,7 @@ placeholder="SECRET_KEY=your_secret&#10;DATABASE_URL=sqlite:///db.sqlite3&#10;DE
             <div class="es-header">
               <div class="es-num">8</div>
               <div class="es-title">Screenshots</div>
+              <button class="collapse-btn" onclick="toggleSection('sec-screenshots')"  aria-label="Toggle section">&#9660;</button>
             </div>
             <div class="es-body">
               <div>
@@ -345,6 +352,7 @@ placeholder="SECRET_KEY=your_secret&#10;DATABASE_URL=sqlite:///db.sqlite3&#10;DE
             <div class="es-header">
               <div class="es-num">9</div>
               <div class="es-title">API Documentation</div>
+              <button class="collapse-btn" onclick="toggleSection('sec-api')"  aria-label="Toggle section">&#9660;</button>
             </div>
             <div class="es-body">
               <div>
@@ -366,6 +374,7 @@ placeholder="SECRET_KEY=your_secret&#10;DATABASE_URL=sqlite:///db.sqlite3&#10;DE
             <div class="es-header">
               <div class="es-num">10</div>
               <div class="es-title">Contributing</div>
+              <button class="collapse-btn" onclick="toggleSection('sec-contributing')"  aria-label="Toggle section">&#9660;</button>
             </div>
             <div class="es-body">
               <div>
@@ -383,6 +392,7 @@ placeholder="SECRET_KEY=your_secret&#10;DATABASE_URL=sqlite:///db.sqlite3&#10;DE
             <div class="es-header">
               <div class="es-num">11</div>
               <div class="es-title">License &amp; Author</div>
+              <button class="collapse-btn" onclick="toggleSection('sec-author')"  aria-label="Toggle section">&#9660;</button>
             </div>
             <div class="es-body">
               <div class="two-col">

--- a/readmeforge.css
+++ b/readmeforge.css
@@ -1474,6 +1474,43 @@ select option {
   line-height: 1.5;
 }
 
+/* ── COLLAPSIBLE SECTIONS ── */
+.collapse-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 12px;
+  margin-left: auto;         /* pushes arrow to the right */
+  padding: 4px 8px;
+  transition: transform 0.25s ease, color 0.2s;
+  line-height: 1;
+}
+
+.collapse-btn:hover {
+  color: var(--accent);
+}
+
+.editor-section.collapsed .collapse-btn {
+  transform: rotate(-90deg);
+}
+
+/* Hide the body when collapsed */
+.editor-section.collapsed .es-body {
+  display: none;
+}
+
+/* Small dot indicator — shows when collapsed + has content */
+.has-content-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background-color: var(--accent);
+  display: inline-block;
+  margin-left: 8px;
+  flex-shrink: 0;
+}
+
 /* =======================================================
    FOOTER SECTION
 ======================================================= */

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -387,6 +387,7 @@
       updateStructurePreview();
     }
     scheduleRender();
+    loadCollapsedState();
   }
 
   // ── UI BUILDERS ───────────────────────────────────────────────
@@ -1424,6 +1425,7 @@
     clearTimeout(renderTimer);
     renderTimer = setTimeout(render, 120);
     scheduleSave();
+    updateAllContentDots();
   }
   window.scheduleRender = scheduleRender;  // Expose globally for HTML
 
@@ -1958,7 +1960,8 @@
     toast("✓ Reset complete!");
   }
   window.resetAll = resetAll;  // Expose globally for HTML
-
+  window.toggleSection = toggleSection;
+  
   // ── HELPERS ───────────────────────────────────────────────────
   /**
    * Shows a temporary notification toast message.
@@ -2018,6 +2021,53 @@
    * @param {HTMLElement} wordCountText - Element to display "Word" or "Words"
    * @returns {void}
    */
+   function loadCollapsedState() {
+    var saved = localStorage.getItem('rf_collapsed_sections');
+    if (!saved) return;
+    var collapsedMap = JSON.parse(saved);
+    Object.keys(collapsedMap).forEach(function(sectionId) {
+      if (collapsedMap[sectionId]) {
+        var section = document.getElementById(sectionId);
+        if (section) section.classList.add('collapsed');
+      }
+    });
+  }
+
+  function toggleSection(sectionId) {
+    var section = document.getElementById(sectionId);
+    if (!section) return;
+    section.classList.toggle('collapsed');
+
+    var collapsedMap = {};
+    document.querySelectorAll('.editor-section').forEach(function(sec) {
+      collapsedMap[sec.id] = sec.classList.contains('collapsed');
+    });
+    localStorage.setItem('rf_collapsed_sections', JSON.stringify(collapsedMap));
+
+    updateContentDot(section);
+  }
+
+  function updateContentDot(section) {
+    var header = section.querySelector('.es-header');
+    var inputs = section.querySelectorAll('input, textarea, select');
+    var hasContent = Array.from(inputs).some(function(el) {
+      return el.value && el.value.trim() !== '';
+    });
+
+    var existingDot = header.querySelector('.has-content-dot');
+    if (existingDot) existingDot.remove();
+
+    if (section.classList.contains('collapsed') && hasContent) {
+      var dot = document.createElement('span');
+      dot.className = 'has-content-dot';
+      dot.title = 'This section has content';
+      header.appendChild(dot);
+    }
+  }
+
+  function updateAllContentDots() {
+    document.querySelectorAll('.editor-section').forEach(updateContentDot);
+  }
   function enableWordCount(inputEl, countEl, wordCountText) {
     inputEl.addEventListener("input", () => {
       const text = inputEl.value.trim();


### PR DESCRIPTION
 Closes #20 

## Changes Made  
-Added toggle arrow on every section header
-Click to expand/collapse sections
-Saved open/closed state using 'localStorage'
-Restores section state after refresh
-Blue dot remains visible for filled collapsed sections
-No console errors after implementation

##Screenshots
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/7b465c93-04bc-4e16-a7ea-465833061b73" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/12867939-f9e3-40fe-97bb-f56bdf377743" />
