### PR TITLE
feat: add Ctrl+Shift+C keyboard shortcut to copy markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
         </a>
         <button class="hbtn" onclick="clearSavedData()">🗑 Clear Saved</button>
         <button class="hbtn" onclick="resetAll()">↺ Reset</button>
-        <button class="hbtn" onclick="copyMarkdown()">Copy MD</button>
+        <button class="hbtn" onclick="copyMarkdown()" title="Copy Markdown (Ctrl+Shift+C)">Copy MD</button>
         <button class="hbtn primary" id="modalPrintBtn" onclick="downloadPDF()">
           ⬇ Download PDF
         </button>

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -2039,7 +2039,13 @@
       }
     });
   }
-
+  
+  document.addEventListener('keydown', function(e) {
+    if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'C') {
+      e.preventDefault();
+      copyMarkdown();
+    }
+  });
 
   init();
 })();


### PR DESCRIPTION
## Summary
Adds a keyboard shortcut (Ctrl+Shift+C / Cmd+Shift+C) that triggers 
the Copy Markdown action, allowing power users to copy the generated 
README without reaching for the mouse.

## Changes Made
- `readmeforge.js` — Added a `keydown` event listener that calls the 
   existing `copyMarkdown()` function when Ctrl+Shift+C is pressed
- `index.html` — Added a `title` attribute to the Copy button showing 
   the shortcut hint on hover

## How It Works
- Ctrl+Shift+C triggers the copy on Windows and Linux
- Cmd+Shift+C triggers the copy on Mac
- `e.preventDefault()` stops any browser default behavior
- Uses the already existing `copyMarkdown()` function — no duplicate logic

Closes issue: #5 