### PR TITLE
feat: smooth scroll and highlight preview on section toggle

### DIFF
--- a/readmeforge.css
+++ b/readmeforge.css
@@ -2325,3 +2325,14 @@ select option {
     display: none !important;
   }
 }
+
+@keyframes sectionGlow {
+  0%   { background-color: transparent; }
+  30%  { background-color: rgba(56, 189, 248, 0.2); }
+  100% { background-color: transparent; }
+}
+
+.section-highlight {
+  border-radius: 4px;
+  animation: sectionGlow 1.5s ease-out forwards;
+}

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -428,8 +428,11 @@
         updateSectionCount();
         scheduleSave();
         scheduleRender();
-      });
-      
+        if (e.target.checked) {               
+          scrollToSectionInPreview(s.id);     
+         }
+        });
+        
       // Hide the section editor if this section is disabled
       var secEl = document.getElementById(s.el);
       if (secEl && !on) secEl.classList.add("hidden");
@@ -2105,6 +2108,58 @@
 
   // Initialize dark mode on page load
   initializeDarkMode();
+  // ── SMOOTH SCROLL ON TOGGLE ──
+  function scrollToSectionInPreview(sectionId) {
+    setTimeout(function() {
+      var previewBody = document.getElementById('previewBody');
+
+      var headingMap = {
+        'title':        'My Project',
+        'description':  'Description',
+        'features':     'Features',
+        'techstack':    'Tech Stack',
+        'installation': 'Installation',
+        'usage':        'Usage',
+        'structure':    'Project Structure',
+        'screenshots':  'Screenshots',
+        'api':          'API Reference',
+        'contributing': 'Contributing',
+        'author':       'Author'
+      };
+
+      var headings = previewBody.querySelectorAll('h1, h2, h3');
+      var target = null;
+
+      headings.forEach(function(h) {
+        if (sectionId === 'title') {
+          if (h.tagName === 'H1') target = h;
+          } else {
+          if (h.textContent.includes(headingMap[sectionId])) target = h;
+          }
+      });
+
+      if (target) {
+       var previewContainer = document.getElementById('previewBody');
+  
+       var containerRect = previewContainer.getBoundingClientRect();
+       var targetRect = target.getBoundingClientRect();
+
+       var scrollOffset = previewContainer.scrollTop + (targetRect.top - containerRect.top) - 100;
+  
+       previewContainer.scrollTo({
+        top: scrollOffset,
+        behavior: 'smooth'
+      });
+
+      target.classList.add('section-highlight');
+      setTimeout(function() {
+        target.classList.remove('section-highlight');
+      }, 1500);
+          }
+        }, 300);
+      }
+
+   window.scrollToSectionInPreview = scrollToSectionInPreview;
 
   init();
 })();


### PR DESCRIPTION
## Summary
Adds smooth scroll and highlight animation to the preview panel when a section is toggled ON in the sidebar.

## Changes Made
- `readmeforge.js` — Added `scrollToSectionInPreview()` that scrolls the preview panel to the toggled section and triggers a glow animation. Only fires when toggling ON.
- `readmeforge.css` — Added `@keyframes sectionGlow` and `.section-highlight` for the cyan highlight effect.

## Acceptance Criteria
- [x] Preview scrolls to toggled section smoothly
- [x] Highlight animation plays and fades out
- [x] Works scrolling both up and down
- [x] Only triggers on ON, not OFF
- [x] No console errors

Closes #6 