### PR TITLE
feat: Add Back to Top button in preview panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,6 +567,13 @@ placeholder="SECRET_KEY=your_secret&#10;DATABASE_URL=sqlite:///db.sqlite3&#10;DE
             <p>Start filling in the editor →</p>
           </div>
         </div>
+
+        <!-- Back to Top Button -->
+        <button id="backToTopBtn" class="back-to-top-btn" title="Back to Top">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="18 15 12 9 6 15"></polyline>
+          </svg>
+        </button>
       </aside>
     </div>
   </div>

--- a/readmeforge.css
+++ b/readmeforge.css
@@ -641,6 +641,7 @@ body.light-mode .hero-title {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 /* ── SIDEBAR ── */
@@ -2212,6 +2213,40 @@ select option {
 .autosave-status.visible {
   opacity: 1;
 }
+
+/* ── BACK TO TOP BUTTON ── */
+.back-to-top-btn {
+  position: absolute;
+  bottom: 24px;
+  right: 24px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: white;
+  border: none;
+  box-shadow: 0 4px 12px rgba(56, 189, 248, 0.4);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.2s ease;
+}
+
+.back-to-top-btn.show {
+  opacity: 1;
+  visibility: visible;
+}
+
+.back-to-top-btn:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 6px 16px rgba(56, 189, 248, 0.6);
+  background: var(--accent2);
+}
+
 /* ── PRINT MEDIA STYLES ── */
 @media print {
 

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -2106,5 +2106,31 @@
   // Initialize dark mode on page load
   initializeDarkMode();
 
+  /**
+   * Initialize Back to Top functionality
+   * @function initBackToTop
+   * @returns {void}
+   */
+  function initBackToTop() {
+    var previewBody = document.getElementById("previewBody");
+    var backToTopBtn = document.getElementById("backToTopBtn");
+
+    if (previewBody && backToTopBtn) {
+      previewBody.addEventListener("scroll", function() {
+        if (previewBody.scrollTop > 200) {
+          backToTopBtn.classList.add("show");
+        } else {
+          backToTopBtn.classList.remove("show");
+        }
+      });
+
+      backToTopBtn.addEventListener("click", function() {
+        previewBody.scrollTo({ top: 0, behavior: "smooth" });
+      });
+    }
+  }
+
+  initBackToTop();
+
   init();
 })();


### PR DESCRIPTION
Resolves #22. Added a smooth-scrolling 'Back to Top' button at the bottom right of the preview panel, which appears when scrolled down.