### PR TITLE
fix: Remove obsolete Usage section to fix skipped section 6 numbering

### DIFF
--- a/readmeforge.js
+++ b/readmeforge.js
@@ -194,7 +194,6 @@
       el: "sec-installation",
       default: true,
     },
-    { id: "usage", label: "Usage", icon: "💻", el: "sec-usage", default: true },
     {
       id: "structure",
       label: "Folder Structure",


### PR DESCRIPTION
Fixes #77

## Problem
Section 6 was being skipped in the README builder sidebar because the  array in  contained an obsolete  entry (pointing to ) that had no corresponding HTML element. The Usage functionality was already merged into the Installation section, but the stale array entry remained, causing the sidebar to render a non-functional section slot and skip number 6 in the displayed sequence.

## Fix
Removed the obsolete `{ id: "usage", ... }` entry from the `SECTIONS` array. Now all sections are sequential with no gaps.

## Testing
- Sections now render in correct sequential order: 1 → 2 → 3 → 4 → 5 → 6 → ... with no skip
- All existing section toggles, templates, and export functionality work without errors
- No console errors introduced