### PR TITLE
fix: add confirmation dialog and snapshot history before reset #85

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,41 @@
       font-size: 13px !important;
       padding: 7px 14px !important;
     }
+
+    .history-list {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .history-item {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 12px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface2);
+    }
+
+    .history-item-meta {
+      font-size: 12px;
+      color: var(--muted);
+      line-height: 1.4;
+      font-family: "JetBrains Mono", monospace;
+    }
+
+    .history-restore-btn {
+      width: 100%;
+      justify-content: center;
+    }
+
+    .history-empty {
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.5;
+      padding: 8px 2px;
+    }
   </style>
 </head>
 
@@ -154,6 +189,7 @@
           Source
         </a>
         <button class="hbtn" onclick="clearSavedData()">🗑 Clear Saved</button>
+        <button class="hbtn" id="historyButton" onclick="toggleHistoryPanel()">🕘 History</button>
         <button class="hbtn" onclick="resetAll()">↺ Reset All Fields</button>
         <button class="hbtn" onclick="copyMarkdown()">Copy Markdown</button>
         <button class="theme-toggle" id="themeToggle" title="Toggle dark/light mode">
@@ -203,6 +239,13 @@
         <div class="sidebar-section" style="flex: 1">
           <div class="sidebar-label">Sections</div>
           <div class="section-toggles" id="sectionToggles">
+            <!-- populated by JS -->
+          </div>
+        </div>
+
+        <div class="sidebar-section history-panel hidden" id="historyPanel">
+          <div class="sidebar-label">Restore History</div>
+          <div id="historyList" class="history-list">
             <!-- populated by JS -->
           </div>
         </div>

--- a/readmeforge.css
+++ b/readmeforge.css
@@ -580,6 +580,12 @@ body.light-mode .hero-title {
   box-shadow: 0 8px 25px rgba(56, 189, 248, 0.5);
 }
 
+.hbtn.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.18);
+}
+
 /* ── Dark Mode Toggle ── */
 .theme-toggle {
   padding: 8px 12px;
@@ -648,6 +654,14 @@ body.light-mode .hero-title {
 .sidebar-section {
   padding: 20px;
   border-bottom: 1px solid var(--border);
+}
+
+.sidebar-section.hidden {
+  display: none;
+}
+
+.sidebar.history-open .history-panel.hidden {
+  display: block;
 }
 
 .sidebar-label {

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -54,6 +54,8 @@
 
   // ── localStorage Auto-Save ────────────────────────────────────
   var STORAGE_KEY = "readmeforge-data";
+  var HISTORY_KEY = "readmeforge-history";
+  var MAX_HISTORY = 15;
 
   var FIELD_IDS = [
     "projName", "tagline", "ghUser", "repoSlug", "description", "demoUrl",
@@ -64,6 +66,15 @@
   ];
 
   function saveToLocalStorage() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(captureSavedState()));
+      showAutoSavedIndicator();
+    } catch (e) {
+      console.error("Auto-save failed:", e);
+    }
+  }
+
+  function captureSavedState() {
     var data = {
       fields: {},
       license: (document.getElementById("license") || {}).value || "MIT",
@@ -75,13 +86,181 @@
       var el = document.getElementById(id);
       if (el) data.fields[id] = el.value;
     });
+    return data;
+  }
+
+  function captureFullState() {
+    var data = captureSavedState();
+    data.screenshots = screenshots.map(function (ss) {
+      return {
+        name: ss.name,
+        dataUrl: ss.dataUrl
+      };
+    });
+    return data;
+  }
+
+  function applySavedState(data) {
+    if (!data || typeof data !== "object" || !data.fields) return false;
+
+    FIELD_IDS.forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el && typeof data.fields[id] === "string") el.value = data.fields[id];
+    });
+
+    var licenseEl = document.getElementById("license");
+    if (licenseEl && data.license) licenseEl.value = data.license;
+
+    selectedTechs = Array.isArray(data.techs) ? new Set(data.techs) : new Set();
+    selectedBadges = Array.isArray(data.badges)
+      ? new Set(data.badges)
+      : new Set(["license", "stars", "prs"]);
+
+    if (data.sections && typeof data.sections === "object") {
+      Object.keys(sectionState).forEach(function (id) {
+        if (Object.prototype.hasOwnProperty.call(data.sections, id)) {
+          sectionState[id] = !!data.sections[id];
+        }
+      });
+    }
+
+    if (Array.isArray(data.screenshots)) {
+      screenshots = data.screenshots.map(function (ss) {
+        return {
+          name: ss.name,
+          dataUrl: ss.dataUrl
+        };
+      });
+      renderScreenshotList();
+    }
+
+    return true;
+  }
+
+  function readHistoryStack() {
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-      showAutoSavedIndicator();
+      var raw = localStorage.getItem(HISTORY_KEY);
+      if (!raw) return [];
+      var history = JSON.parse(raw);
+      if (!Array.isArray(history)) return [];
+      return history.filter(function (entry) {
+        return entry && typeof entry === "object" && entry.timestamp && entry.state;
+      }).slice(0, MAX_HISTORY);
     } catch (e) {
-      console.error("Auto-save failed:", e);
+      console.error("Failed to read history:", e);
+      return [];
     }
   }
+
+  function writeHistoryStack(history) {
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(history.slice(0, MAX_HISTORY)));
+  }
+
+  function renderHistoryPanel() {
+    var el = document.getElementById("historyList");
+    if (!el) return;
+
+    var history = readHistoryStack();
+    if (!history.length) {
+      el.innerHTML = '<div class="history-empty">No reset snapshots yet.</div>';
+      return;
+    }
+
+    el.innerHTML = history
+      .map(function (entry, index) {
+        var snapshotTime = entry.timestamp ? new Date(entry.timestamp) : null;
+        var timeLabel = snapshotTime && !isNaN(snapshotTime.getTime())
+          ? snapshotTime.toLocaleString()
+          : "Unknown time";
+        var fieldCount = entry.state && entry.state.fields
+          ? Object.keys(entry.state.fields).length
+          : 0;
+        var screenshotCount = entry.state && Array.isArray(entry.state.screenshots)
+          ? entry.state.screenshots.length
+          : 0;
+        return (
+          '<div class="history-item">' +
+          '<div class="history-item-meta">' +
+          timeLabel +
+          ' • ' +
+          fieldCount +
+          ' fields' +
+          (screenshotCount ? ' • ' + screenshotCount + ' screenshots' : '') +
+          '</div>' +
+          '<button class="hbtn history-restore-btn" onclick="restoreSnapshot(' +
+          index +
+          ')">Restore</button>' +
+          '</div>'
+        );
+      })
+      .join("");
+  }
+
+  function pushToHistory(state) {
+    var history = readHistoryStack();
+    history.unshift({
+      timestamp: new Date().toISOString(),
+      state: state
+    });
+    writeHistoryStack(history);
+    renderHistoryPanel();
+  }
+  window.pushToHistory = pushToHistory;
+
+  function openHistoryPanel() {
+    var sidebar = document.querySelector(".sidebar");
+    var panel = document.getElementById("historyPanel");
+    var button = document.getElementById("historyButton");
+    if (sidebar) sidebar.classList.add("history-open");
+    if (panel) panel.classList.remove("hidden");
+    if (button) button.classList.add("active");
+    renderHistoryPanel();
+  }
+
+  function toggleHistoryPanel() {
+    var sidebar = document.querySelector(".sidebar");
+    var panel = document.getElementById("historyPanel");
+    var button = document.getElementById("historyButton");
+    var isOpen = sidebar && sidebar.classList.contains("history-open");
+    if (isOpen) {
+      if (sidebar) sidebar.classList.remove("history-open");
+      if (panel) panel.classList.add("hidden");
+      if (button) button.classList.remove("active");
+      return;
+    }
+    openHistoryPanel();
+  }
+  window.openHistoryPanel = openHistoryPanel;
+  window.toggleHistoryPanel = toggleHistoryPanel;
+
+  function restoreSnapshot(index) {
+    var history = readHistoryStack();
+    var entry = history[index];
+    if (!entry || !entry.state) {
+      toast("Snapshot not found.");
+      return;
+    }
+
+    clearTimeout(saveTimer);
+    saveTimer = null;
+
+    pushToHistory(captureFullState());
+    applySavedState(entry.state);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(captureSavedState()));
+    } catch (e) {
+      console.error("Failed to restore saved data:", e);
+    }
+
+    buildBadgePicker();
+    updateTechCount();
+    buildSectionToggles();
+    updateSectionCount();
+    openHistoryPanel();
+    scheduleRender();
+    toast("✓ Snapshot restored!");
+  }
+  window.restoreSnapshot = restoreSnapshot;
 
   function loadFromLocalStorage() {
     try {
@@ -95,26 +274,7 @@
         return false;
       }
 
-      FIELD_IDS.forEach(function (id) {
-        var el = document.getElementById(id);
-        if (el && typeof data.fields[id] === "string") el.value = data.fields[id];
-      });
-
-      var licenseEl = document.getElementById("license");
-      if (licenseEl && data.license) licenseEl.value = data.license;
-
-      if (Array.isArray(data.techs)) selectedTechs = new Set(data.techs);
-      if (Array.isArray(data.badges)) selectedBadges = new Set(data.badges);
-
-      if (data.sections && typeof data.sections === "object") {
-        Object.keys(data.sections).forEach(function (id) {
-          if (Object.prototype.hasOwnProperty.call(sectionState, id)) {
-            sectionState[id] = !!data.sections[id];
-          }
-        });
-      }
-
-      return true;
+      return applySavedState(data);
     } catch (e) {
       console.error("Auto-save: failed to restore data:", e);
       return false;
@@ -393,6 +553,7 @@
       });
       updateStructurePreview();
     }
+    renderHistoryPanel();
     scheduleRender();
   }
 
@@ -1949,6 +2110,15 @@
    * @returns {void}
    */
   function resetAll() {
+    if (!window.confirm("Are you sure? This will clear all your fields.")) {
+      return;
+    }
+
+    clearTimeout(saveTimer);
+    saveTimer = null;
+
+    pushToHistory(captureFullState());
+
     // Clear all text inputs, email inputs, URLs, and textareas
     document
       .querySelectorAll(
@@ -2007,6 +2177,7 @@
     } catch (e) {
       console.error("Failed to clear saved data on reset:", e);
     }
+    renderHistoryPanel();
     scheduleRender();
     toast("✓ Reset complete!");
   }

--- a/readmeforge.js
+++ b/readmeforge.js
@@ -554,6 +554,8 @@
       updateStructurePreview();
     }
     renderHistoryPanel();
+    if (typeof applyPreviewZoom === "function") applyPreviewZoom();
+    if (typeof setupZoomShortcuts === "function") setupZoomShortcuts();
     scheduleRender();
   }
 


### PR DESCRIPTION
 ##What this PR does
- Added a confirmation dialog before "Reset All Fields" executes to prevent accidental data loss
- Automatically snapshots the full editor state (via localStorage) before every reset — so nothing is lost
- Maintains a rolling history of up to 10 timestamped snapshots, stored entirely in localStorage
- Introduced a History panel in the UI where users can browse past snapshots and restore any previous state with a single click
- Fully zero-dependency and browser-based, consistent 
  with the existing localStorage architecture of the app

## Issue
Closes #85

## Testing
- Click Reset All Fields → confirmation dialog appears
- Confirm reset → snapshot saved in history
- Open History panel → snapshots visible with timestamps
- Click Restore → previous state recovered successfully

<img width="1837" height="813" alt="Screenshot 2026-05-13 020914" src="https://github.com/user-attachments/assets/4c2302ca-0299-40b0-b3ca-48ccca2839fa" />
<img width="1244" height="879" alt="image" src="https://github.com/user-attachments/assets/7cdd6670-dd2b-4502-8836-24b004b11593" />
