### PR TITLE
feature: add academic research template

### DIFF
--- a/src/hooks/useReadmeState.js
+++ b/src/hooks/useReadmeState.js
@@ -10,6 +10,7 @@ const initialFormData = {
   contribNotes: '', authorName: '', authorGh: '', authorEmail: '',
   authorLinkedin: '', authorWebsite: '', customTech: '', license: 'MIT',
   supportMsg: '', supportBmac: '', supportKofi: '', supportPatreon: '', supportGhSponsors: '',
+  abstractText: '', paperLink: '', datasetLink: '', methodology: '', bibtexCitation: '',
 };
 
 function buildDefaultSectionState() {
@@ -101,10 +102,17 @@ export function useReadmeState() {
         tagline: template.tag,
         description: template.desc,
         features: template.features,
+        abstractText: template.abstractText || '',
+        paperLink: template.paperLink || '',
+        datasetLink: template.datasetLink || '',
+        methodology: template.methodology || '',
+        bibtexCitation: template.bibtexCitation || '',
       };
-      scheduleSave(next, sectionState, new Set(template.techs), selectedBadges);
+      const nextSections = { ...sectionState, academic: !!template.abstractText };
+      scheduleSave(next, nextSections, new Set(template.techs), selectedBadges);
       return next;
     });
+    setSectionState(prev => ({ ...prev, academic: !!template.abstractText }));
     setSelectedTechs(new Set(template.techs));
   }, [sectionState, selectedBadges, scheduleSave]);
 

--- a/src/pages/ReadmeMaker/EditorPanel.jsx
+++ b/src/pages/ReadmeMaker/EditorPanel.jsx
@@ -116,6 +116,42 @@ export default function EditorPanel({
           </div>
         </EditorSection>
 
+        <EditorSection num="3A" title="Academic / Research Details" hidden={!sectionState.academic}>
+          <div>
+            <label>ABSTRACT</label>
+            <textarea className="textInput" id="abstractText" style={{ minHeight: 100 }}
+              placeholder="Summarize the research problem, approach, and key findings."
+              value={formData.abstractText} onChange={e => updateField('abstractText', e.target.value)} />
+            <WordCount text={formData.abstractText} />
+          </div>
+          <div className="two-col">
+            <div>
+              <label>PAPER LINK</label>
+              <input type="url" id="paperLink" placeholder="https://arxiv.org/abs/..."
+                value={formData.paperLink} onChange={e => updateField('paperLink', e.target.value)} />
+            </div>
+            <div>
+              <label>DATASET ACCESS</label>
+              <input type="url" id="datasetLink" placeholder="https://doi.org/... or https://huggingface.co/datasets/..."
+                value={formData.datasetLink} onChange={e => updateField('datasetLink', e.target.value)} />
+            </div>
+          </div>
+          <div>
+            <label>METHODOLOGY</label>
+            <textarea className="textInput" id="methodology" style={{ minHeight: 100 }}
+              placeholder={'### Data Collection\n- Describe dataset source and preprocessing\n\n### Experiments\n- Describe model, baselines, and evaluation metrics'}
+              value={formData.methodology} onChange={e => updateField('methodology', e.target.value)} />
+            <WordCount text={formData.methodology} />
+          </div>
+          <div>
+            <label>CITATIONS / BIBTEX</label>
+            <textarea className="textInput" id="bibtexCitation" style={{ minHeight: 120 }}
+              placeholder={'@article{yourpaper2026,\n  title={Your Paper Title},\n  author={First Author and Second Author},\n  journal={Conference or Journal},\n  year={2026}\n}'}
+              value={formData.bibtexCitation} onChange={e => updateField('bibtexCitation', e.target.value)} />
+            <WordCount text={formData.bibtexCitation} />
+          </div>
+        </EditorSection>
+
         <EditorSection num={3} title="Features" hidden={!sectionState.features}>
           <div>
             <label>KEY FEATURES — use "### Category" for groups, "- item" for bullets</label>

--- a/src/pages/ReadmeMaker/Sidebar.jsx
+++ b/src/pages/ReadmeMaker/Sidebar.jsx
@@ -22,6 +22,7 @@ export default function Sidebar({
               {key === 'ml' && '🤖 ML / AI'}
               {key === 'api' && '⚡ Backend API'}
               {key === 'cli' && '💻 CLI Tool'}
+              {key === 'academic' && '🎓 Academic / Research'}
               {key === 'mobile' && '📱 Mobile App'}
               {key === 'lib' && '📦 Library'}
               {key === 'hackathon' && '🏆 Hackathon'}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,6 +2,7 @@ export const SECTIONS = [
   { id: 'title', label: 'Project Title', icon: '📌', el: 'sec-title', default: true },
   { id: 'description', label: 'Description', icon: '📋', el: 'sec-description', default: true },
   { id: 'features', label: 'Features', icon: '✨', el: 'sec-features', default: true },
+  { id: 'academic', label: 'Academic Details', icon: '📚', el: 'sec-academic', default: false },
   { id: 'techstack', label: 'Tech Stack', icon: '🛠️', el: 'sec-techstack', default: true },
   { id: 'installation', label: 'Installation', icon: '🚀', el: 'sec-installation', default: true },
   { id: 'structure', label: 'Folder Structure', icon: '📁', el: 'sec-structure', default: true },
@@ -89,6 +90,18 @@ export const TEMPLATES = {
     desc: 'A command-line tool that helps developers automate repetitive tasks. Supports plugins, configuration files, and shell completions.',
     features: '### ⚙️ Commands\n- Multiple sub-commands\n- Interactive prompts\n\n### 🔌 Plugins\n- Plugin system\n- Custom hooks\n\n### 🐚 Shell\n- Bash/Zsh/Fish completions\n- Cross-platform support',
   },
+  academic: {
+    name: 'Research Project',
+    tag: 'Reproducible research, paper artifacts, and dataset access',
+    techs: ['Python', 'PyTorch'],
+    desc: 'A research repository for sharing paper artifacts, reproducible experiments, dataset access details, and citation information.',
+    features: '### Research Artifacts\n- Reproducible experiment scripts\n- Evaluation notebooks and figures\n\n### Results\n- Baseline comparisons\n- Ablation studies\n\n### Reuse\n- Dataset access instructions\n- BibTeX citation block',
+    abstractText: 'This project investigates [research problem] using [method or model]. It provides reproducible code, dataset access instructions, and evaluation artifacts so students and researchers can inspect, cite, and extend the work.',
+    methodology: '### Data Collection\n- Describe the dataset source, inclusion criteria, and preprocessing steps.\n\n### Experimental Setup\n- Document baselines, model configuration, hardware, and hyperparameters.\n\n### Evaluation\n- List the metrics, validation protocol, and statistical tests used.',
+    paperLink: 'https://arxiv.org/abs/0000.00000',
+    datasetLink: 'https://doi.org/10.0000/example-dataset',
+    bibtexCitation: '@article{researchproject2026,\n  title={Research Project Title},\n  author={First Author and Second Author},\n  journal={Conference or Journal Name},\n  year={2026}\n}',
+  },
   mobile: {
     name: 'Mobile App',
     tag: 'Cross-platform mobile app',
@@ -130,4 +143,5 @@ export const FIELD_IDS = [
   'videoUrl', 'imageUrls', 'apiDocs', 'apiBase', 'contribNotes', 'authorName',
   'authorGh', 'authorEmail', 'authorLinkedin', 'authorWebsite', 'customTech',
   'supportMsg', 'supportBmac', 'supportKofi', 'supportPatreon', 'supportGhSponsors',
+  'abstractText', 'paperLink', 'datasetLink', 'methodology', 'bibtexCitation',
 ];

--- a/src/utils/markdownUtils.js
+++ b/src/utils/markdownUtils.js
@@ -97,6 +97,7 @@ export function generateMarkdown({ formData, sectionState, selectedTechs, select
     contribNotes, license, authorName, authorGh, authorEmail,
     authorLinkedin, authorWebsite, customTech, supportMsg,
     supportBmac, supportKofi, supportPatreon, supportGhSponsors,
+    abstractText, paperLink, datasetLink, methodology, bibtexCitation,
   } = formData;
 
   const name = projName || 'My Project';
@@ -129,6 +130,7 @@ export function generateMarkdown({ formData, sectionState, selectedTechs, select
     md += '---\n\n';
     md += '## 📋 Table of Contents\n\n';
     if (on('description')) md += '- [Description](#-description)\n';
+    if (on('academic')) md += '- [Academic / Research Details](#academic--research-details)\n';
     if (on('features')) md += '- [Features](#-features)\n';
     if (on('techstack')) md += '- [Tech Stack](#-tech-stack)\n';
     if (on('installation')) md += '- [Installation](#-installation)\n';
@@ -146,6 +148,31 @@ export function generateMarkdown({ formData, sectionState, selectedTechs, select
     md += (description || '_Add a description of your project here._') + '\n\n';
     if (demoUrl) md += `🔗 **Live Demo:** [${demoUrl}](${demoUrl})\n\n`;
     md += '---\n\n';
+  }
+
+  if (on('academic')) {
+    const hasAcademicContent = abstractText || paperLink || datasetLink || methodology || bibtexCitation;
+    if (hasAcademicContent) {
+      md += '## Academic / Research Details\n\n';
+      const academicBadges = [];
+      if (paperLink) academicBadges.push(`[![Paper](https://img.shields.io/badge/Paper-Read%20Now-blue)](${paperLink})`);
+      if (datasetLink) academicBadges.push(`[![Dataset](https://img.shields.io/badge/Dataset-Access-green)](${datasetLink})`);
+      if (academicBadges.length) md += academicBadges.join(' ') + '\n\n';
+      if (abstractText) md += `### Abstract\n\n${abstractText}\n\n`;
+      if (paperLink) md += `### Paper Link\n\n[${paperLink}](${paperLink})\n\n`;
+      if (datasetLink) md += `### Dataset Access\n\n[${datasetLink}](${datasetLink})\n\n`;
+      if (methodology) {
+        md += '### Methodology\n\n';
+        methodology.split('\n').forEach(line => {
+          const l = line.trimEnd();
+          if (l.trim().startsWith('###')) md += '\n' + l.trim() + '\n';
+          else if (l.trim()) md += (l.trim().startsWith('-') ? l : '- ' + l.trim()) + '\n';
+        });
+        md += '\n';
+      }
+      if (bibtexCitation) md += `### Citation\n\n\`\`\`bibtex\n${bibtexCitation}\n\`\`\`\n\n`;
+      md += '---\n\n';
+    }
   }
 
   if (on('features') && features) {


### PR DESCRIPTION
## Summary
- Added a new Academic / Research template to the README builder
- Added academic fields for Abstract, Paper Link, Dataset Access, Methodology, and BibTeX citations
- Added generated README output for paper/dataset badges, methodology, and citation details

## Testing
- Ran `npm.cmd run build`
- Verified Academic markdown output includes Abstract, Methodology, Dataset Access, Paper badge, and BibTeX citation

Closes #80