### PR TITLE
feature: add multilingual readme support with i18n system #16

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import LanguageSelector from './components/LanguageSelector';
 import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from './hooks/useTheme';
 import { ToastProvider } from './components/ui/Toast';
@@ -8,6 +9,15 @@ export default function App() {
     <BrowserRouter>
       <ThemeProvider>
         <ToastProvider>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              padding: '10px 20px',
+            }}
+          >
+          </div>
+
           <AppRoutes />
         </ToastProvider>
       </ThemeProvider>

--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -1,0 +1,27 @@
+import { useContext } from 'react';
+import { LanguageContext } from '../context/LanguageContext';
+
+const LanguageSelector = () => {
+  const { language, changeLanguage } =
+    useContext(LanguageContext);
+
+  return (
+    <select
+      value={language}
+      onChange={(e) => changeLanguage(e.target.value)}
+      style={{
+        padding: '8px',
+        borderRadius: '6px',
+        cursor: 'pointer',
+      }}
+    >
+      <option value="en">English</option>
+      <option value="hi">Hindi</option>
+      <option value="es">Spanish</option>
+      <option value="fr">French</option>
+      <option value="zh">Chinese</option>
+    </select>
+  );
+};
+
+export default LanguageSelector;

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -1,20 +1,31 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from '../../hooks/useTheme';
 import Logo from '../ui/Logo';
+import LanguageSelector from '../LanguageSelector';
+import { LanguageContext } from '../../context/LanguageContext';
+import { translations } from '../../i18n';
+import { useTranslation } from '../../hooks/useTranslation';
 
 export default function Navbar() {
   const { theme, toggleTheme } = useTheme();
+
+  const { language } = useContext(LanguageContext);
+
   const [menuOpen, setMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+
   const location = useLocation();
+  const t = useTranslation();
 
   useEffect(() => {
     const updateScrollState = () => setIsScrolled(window.scrollY > 0);
 
     updateScrollState();
 
-    window.addEventListener('scroll', updateScrollState, { passive: true });
+    window.addEventListener('scroll', updateScrollState, {
+      passive: true,
+    });
 
     return () => {
       window.removeEventListener('scroll', updateScrollState);
@@ -27,40 +38,64 @@ export default function Navbar() {
 
   const isActiveRoute = (path, exact = false) => {
     if (exact) return location.pathname === path;
-    return location.pathname === path || location.pathname.startsWith(`${path}/`);
+
+    return (
+      location.pathname === path ||
+      location.pathname.startsWith(`${path}/`)
+    );
   };
 
-  const linkClassName = (isActive, extraClass = '') => `site-nav-link${isActive ? ' active' : ''}${extraClass ? ` ${extraClass}` : ''}`;
+  const linkClassName = (isActive, extraClass = '') =>
+    `site-nav-link${isActive ? ' active' : ''}${
+      extraClass ? ` ${extraClass}` : ''
+    }`;
 
   return (
     <nav className={`site-nav${isScrolled ? ' is-scrolled' : ''}`}>
-      <Link to="/" className="logo" onClick={() => setMenuOpen(false)}>
+      <Link
+        to="/"
+        className="logo"
+        onClick={() => setMenuOpen(false)}
+      >
         <Logo size={36} />
-        <span className="logo-name">README<span>Forge</span></span>
+
+        <span className="logo-name">
+          README<span>Forge</span>
+        </span>
       </Link>
 
-      <div id="site-navigation" className={`site-nav-links${menuOpen ? ' open' : ''}`}>
+      <div
+        id="site-navigation"
+        className={`site-nav-links${menuOpen ? ' open' : ''}`}
+      >
         <Link
           to="/"
           className={linkClassName(isActiveRoute('/', true))}
           onClick={() => setMenuOpen(false)}
         >
-          Home
+          {t.home}
         </Link>
+
         <Link
           to="/readme-maker"
-          className={linkClassName(isActiveRoute('/readme-maker'))}
+          className={linkClassName(
+            isActiveRoute('/readme-maker')
+          )}
           onClick={() => setMenuOpen(false)}
         >
-          README Maker
+          {t.readmeMaker}
         </Link>
+
         <Link
           to="/how-to-use"
-          className={linkClassName(isActiveRoute('/how-to-use'))}
+          className={linkClassName(
+            isActiveRoute('/how-to-use')
+          )}
           onClick={() => setMenuOpen(false)}
         >
-          How To Use
+          {t.howToUse}
         </Link>
+
         <a
           href="https://github.com/Mohit-368/ReadmeForge"
           target="_blank"
@@ -68,11 +103,23 @@ export default function Navbar() {
           className="site-nav-link site-nav-link--gh mobile-only"
           onClick={() => setMenuOpen(false)}
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="16 18 22 12 16 6" />
+            <polyline points="8 6 2 12 8 18" />
           </svg>
-          Source
+
+          {t.source}
         </a>
+
         <button
           type="button"
           className="theme-toggle mobile-only"
@@ -81,10 +128,16 @@ export default function Navbar() {
         >
           {theme === 'dark' ? '🌙' : '☀️'}
         </button>
-        {/* Source link moved to actions area so it stays beside theme toggle */}
       </div>
 
-      <div className="site-nav-actions">
+      <div
+        className="site-nav-actions"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+        }}
+      >
         <a
           href="https://github.com/Mohit-368/ReadmeForge"
           target="_blank"
@@ -92,11 +145,24 @@ export default function Navbar() {
           className="site-nav-link site-nav-link--gh desktop-only"
           title="View source on GitHub"
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="16 18 22 12 16 6" />
+            <polyline points="8 6 2 12 8 18" />
           </svg>
-          Source
+
+          {t.source}
         </a>
+
+        <LanguageSelector />
 
         <button
           type="button"

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -1,0 +1,25 @@
+import { createContext, useState } from 'react';
+
+export const LanguageContext = createContext();
+
+export const LanguageProvider = ({ children }) => {
+  const [language, setLanguage] = useState(
+    localStorage.getItem('language') || 'en'
+  );
+
+  const changeLanguage = (lang) => {
+    setLanguage(lang);
+    localStorage.setItem('language', lang);
+  };
+
+  return (
+    <LanguageContext.Provider
+      value={{
+        language,
+        changeLanguage,
+      }}
+    >
+      {children}
+    </LanguageContext.Provider>
+  );
+};

--- a/src/hooks/useTranslation.js
+++ b/src/hooks/useTranslation.js
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { LanguageContext } from '../context/LanguageContext';
+import { translations } from '../i18n';
+
+export const useTranslation = () => {
+  const { language } = useContext(LanguageContext);
+
+  return translations[language];
+};

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1,0 +1,158 @@
+const en = {
+  home: 'Home',
+  readmeMaker: 'README Maker',
+  howToUse: 'How To Use',
+  source: 'Source',
+
+  projectTitle: 'Project Title & Badges',
+  projectName: 'PROJECT NAME *',
+  tagline: 'TAGLINE',
+  githubUser: 'GITHUB USER',
+  repoName: 'REPO NAME',
+
+  description: 'Description',
+  features: 'Features',
+  techStack: 'Tech Stack',
+
+  installation: 'Installation',
+prerequisites: 'PREREQUISITES',
+installCommands: 'INSTALL COMMANDS (one per line)',
+envVariables: 'ENV VARIABLES (optional)',
+runCommand: 'RUN COMMAND / USAGE INSTRUCTIONS',
+
+word: 'Word',
+words: 'Words',
+
+autoBadges: 'AUTO BADGES — click to toggle',
+
+shortDescription: 'SHORT DESCRIPTION',
+
+projectProblem:
+  'What does your project do? What problem does it solve?',
+
+awesomeProject: 'AwesomeProject',
+
+blazingFast: 'A blazing-fast tool for...',
+
+octocat: 'octocat',
+
+awesomeRepo: 'awesome-project',
+
+installation: 'Installation',
+
+prerequisites: 'PREREQUISITES',
+
+installCommands: 'INSTALL COMMANDS (one per line)',
+
+envVariables: 'ENV VARIABLES (optional)',
+
+runCommand: 'RUN COMMAND / USAGE INSTRUCTIONS',
+
+templates: 'Templates',
+sections: 'Sections',
+
+webApp: 'Web App',
+mlAi: 'ML / AI',
+backendApi: 'Backend API',
+cliTool: 'CLI Tool',
+academicResearch: 'Academic / Research',
+mobileApp: 'Mobile App',
+library: 'Library',
+hackathon: 'Hackathon',
+openSource: 'Open Source',
+
+academicDetails: 'Academic / Research Details',
+abstract: 'ABSTRACT',
+paperLink: 'PAPER LINK',
+datasetAccess: 'DATASET ACCESS',
+methodology: 'METHODOLOGY',
+citations: 'CITATIONS / BIBTEX',
+
+keyFeatures:
+  'KEY FEATURES — use "### Category" for groups, "- item" for bullets',
+
+selectStack: 'CLICK TO SELECT YOUR STACK',
+customTech: 'OR ADD CUSTOM (comma separated)',
+
+projectStructure: 'Project Structure Visualizer',
+folderStructure:
+  'PASTE YOUR FOLDER STRUCTURE (indented with spaces)',
+visualPreview: 'VISUAL PREVIEW',
+structurePreview: 'Paste structure above to preview...',
+
+screenshots: 'Screenshots',
+videoLink: 'LIVE DEMO / VIDEO LINK (optional)',
+dragScreenshots: 'DRAG & DROP SCREENSHOTS',
+dropImages: 'Drop images here or click to browse',
+imageFormats:
+  "PNG, JPG, GIF — they'll be linked as Markdown",
+imageUrls:
+  'OR ADD IMAGE URLS (format: Label | URL, one per line)',
+
+apiDocs: 'API Documentation',
+apiEndpoints:
+  'API ENDPOINTS — format: METHOD /path | Description (one per line)',
+apiBaseUrl: 'API BASE URL (optional)',
+
+contributing: 'Contributing',
+contributingNotes:
+  'CUSTOM CONTRIBUTING NOTES (optional — default guide auto-generated)',
+
+licenseAuthor: 'License & Author',
+license: 'LICENSE',
+fullName: 'FULL NAME',
+githubUsername: 'GITHUB USERNAME',
+email: 'EMAIL (optional)',
+linkedin: 'LINKEDIN (optional)',
+portfolio: 'PORTFOLIO (optional)',
+
+supportDonation: 'Support & Donation',
+supportMessage: 'SUPPORT MESSAGE (optional)',
+buyMeCoffee: 'BUY ME A COFFEE (username)',
+kofi: 'KO-FI (username)',
+patreon: 'PATREON (username)',
+githubSponsors: 'GITHUB SPONSORS (username)',
+
+liveDemoUrl: 'LIVE DEMO URL (optional)',
+
+abstractPlaceholder:
+  'Summarize the research problem, approach, and key findings.',
+
+methodologyPlaceholder:
+  '### Data Collection\n- Describe dataset source and preprocessing\n\n### Experiments\n- Describe model, baselines, and evaluation metrics',
+
+citationPlaceholder:
+  '@article{yourpaper2026,\n  title={Your Paper Title},\n  author={First Author and Second Author},\n  journal={Conference or Journal},\n  year={2026}\n}',
+
+featuresPlaceholder:
+  '### 🔐 Authentication\n- Email OTP verification\n- Secure login / logout\n\n### 📝 Posts\n- Create, Read, Update, Delete',
+
+prerequisitesPlaceholder:
+  'Python 3.10+, Node.js 18+',
+
+installPlaceholder:
+  'git clone https://github.com/user/repo.git\ncd repo\npip install -r requirements.txt',
+
+envPlaceholder:
+  'SECRET_KEY=your_secret\nDATABASE_URL=sqlite:///db.sqlite3',
+
+runPlaceholder:
+  'python manage.py runserver\n\n# Then open http://127.0.0.1:8000/',
+
+structurePlaceholder:
+  'src/\n  api/\n  models/\n  utils/\ntemplates/\nmain.py\nrequirements.txt',
+
+imageUrlPlaceholder:
+  'Landing Page | https://i.imgur.com/abc.png\nDashboard | https://i.imgur.com/xyz.png',
+
+apiPlaceholder:
+  'GET /api/users | Get all users\nPOST /api/users | Create a new user',
+
+contributingPlaceholder:
+  'Any specific guidelines, code style rules, branch naming conventions...',
+
+supportPlaceholder:
+  'If you find this project helpful, please consider supporting its development:',
+};
+
+export default en;

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -1,0 +1,160 @@
+const es = {
+  home: 'Inicio',
+  readmeMaker: 'Creador README',
+  howToUse: 'Cómo Usar',
+  source: 'Fuente',
+
+  projectTitle: 'Título del Proyecto y Badges',
+  projectName: 'NOMBRE DEL PROYECTO *',
+  tagline: 'ESLOGAN',
+  githubUser: 'USUARIO DE GITHUB',
+  repoName: 'NOMBRE DEL REPOSITORIO',
+
+  description: 'Descripción',
+  features: 'Características',
+  techStack: 'Stack Tecnológico',
+
+  installation: 'Instalación',
+prerequisites: 'PRERREQUISITOS',
+installCommands: 'COMANDOS DE INSTALACIÓN (uno por línea)',
+envVariables: 'VARIABLES DE ENTORNO (opcional)',
+runCommand: 'COMANDO DE EJECUCIÓN / INSTRUCCIONES',
+
+word: 'Palabra',
+words: 'Palabras',
+
+autoBadges: 'INSIGNIAS AUTOMÁTICAS — haz clic para alternar',
+
+shortDescription: 'DESCRIPCIÓN CORTA',
+
+projectProblem:
+  '¿Qué hace tu proyecto? ¿Qué problema resuelve?',
+
+awesomeProject: 'ProyectoIncreíble',
+
+blazingFast: 'Una herramienta súper rápida para...',
+
+octocat: 'octocat',
+
+awesomeRepo: 'proyecto-increible',
+
+installation: 'Instalación',
+
+prerequisites: 'PRERREQUISITOS',
+
+installCommands: 'COMANDOS DE INSTALACIÓN (uno por línea)',
+
+envVariables: 'VARIABLES DE ENTORNO (opcional)',
+
+runCommand: 'COMANDO DE EJECUCIÓN / INSTRUCCIONES DE USO',
+
+templates: 'Plantillas',
+sections: 'Secciones',
+
+webApp: 'Aplicación Web',
+mlAi: 'ML / IA',
+backendApi: 'API Backend',
+cliTool: 'Herramienta CLI',
+academicResearch: 'Académico / Investigación',
+mobileApp: 'Aplicación Móvil',
+library: 'Librería',
+hackathon: 'Hackathon',
+openSource: 'Código Abierto',
+
+academicDetails: 'Detalles Académicos / Investigación',
+abstract: 'RESUMEN',
+paperLink: 'ENLACE DEL ARTÍCULO',
+datasetAccess: 'ACCESO AL DATASET',
+methodology: 'METODOLOGÍA',
+citations: 'CITAS / BIBTEX',
+
+keyFeatures:
+  'CARACTERÍSTICAS PRINCIPALES — usa "### Category" para grupos y "- item" para listas',
+
+selectStack: 'HAZ CLIC PARA SELECCIONAR TU STACK',
+customTech: 'O AGREGA PERSONALIZADO (separado por comas)',
+
+projectStructure: 'Visualizador de Estructura del Proyecto',
+folderStructure:
+  'PEGA LA ESTRUCTURA DE TU CARPETA (indentada con espacios)',
+visualPreview: 'VISTA PREVIA VISUAL',
+structurePreview:
+  'Pega la estructura arriba para ver la vista previa...',
+
+screenshots: 'Capturas de Pantalla',
+videoLink: 'ENLACE DE DEMO / VIDEO (opcional)',
+dragScreenshots: 'ARRASTRA Y SUELTA CAPTURAS',
+dropImages:
+  'Suelta imágenes aquí o haz clic para explorar',
+imageFormats:
+  'PNG, JPG, GIF — serán enlazados como Markdown',
+imageUrls:
+  'O AGREGA URLS DE IMÁGENES (formato: Label | URL, una por línea)',
+
+apiDocs: 'Documentación API',
+apiEndpoints:
+  'API ENDPOINTS — formato: METHOD /path | Descripción (una por línea)',
+apiBaseUrl: 'URL BASE API (opcional)',
+
+contributing: 'Contribución',
+contributingNotes:
+  'NOTAS PERSONALIZADAS DE CONTRIBUCIÓN (opcional — guía generada automáticamente)',
+
+licenseAuthor: 'Licencia y Autor',
+license: 'LICENCIA',
+fullName: 'NOMBRE COMPLETO',
+githubUsername: 'NOMBRE DE USUARIO GITHUB',
+email: 'EMAIL (opcional)',
+linkedin: 'LINKEDIN (opcional)',
+portfolio: 'PORTAFOLIO (opcional)',
+
+supportDonation: 'Soporte y Donación',
+supportMessage: 'MENSAJE DE SOPORTE (opcional)',
+buyMeCoffee: 'BUY ME A COFFEE (usuario)',
+kofi: 'KO-FI (usuario)',
+patreon: 'PATREON (usuario)',
+githubSponsors: 'GITHUB SPONSORS (usuario)',
+
+liveDemoUrl: 'URL DE DEMOSTRACIÓN EN VIVO (opcional)',
+
+abstractPlaceholder:
+  'Resume el problema de investigación, el enfoque y los hallazgos principales.',
+
+methodologyPlaceholder:
+  '### Recolección de Datos\n- Describe la fuente y el preprocesamiento del conjunto de datos\n\n### Experimentos\n- Describe el modelo, las líneas base y las métricas de evaluación',
+
+citationPlaceholder:
+  '@article{yourpaper2026,\n  title={Título de tu artículo},\n  author={Primer Autor y Segundo Autor},\n  journal={Conferencia o Revista},\n  year={2026}\n}',
+
+featuresPlaceholder:
+  '### 🔐 Autenticación\n- Verificación OTP por correo electrónico\n- Inicio / cierre de sesión seguro\n\n### 📝 Publicaciones\n- Crear, Leer, Actualizar, Eliminar',
+
+prerequisitesPlaceholder:
+  'Python 3.10+, Node.js 18+',
+
+installPlaceholder:
+  'git clone https://github.com/user/repo.git\ncd repo\npip install -r requirements.txt',
+
+envPlaceholder:
+  'SECRET_KEY=your_secret\nDATABASE_URL=sqlite:///db.sqlite3',
+
+runPlaceholder:
+  'python manage.py runserver\n\n# Luego abre http://127.0.0.1:8000/',
+
+structurePlaceholder:
+  'src/\n  api/\n  models/\n  utils/\ntemplates/\nmain.py\nrequirements.txt',
+
+imageUrlPlaceholder:
+  'Página Principal | https://i.imgur.com/abc.png\nPanel | https://i.imgur.com/xyz.png',
+
+apiPlaceholder:
+  'GET /api/users | Obtener todos los usuarios\nPOST /api/users | Crear un nuevo usuario',
+
+contributingPlaceholder:
+  'Cualquier guía específica, reglas de estilo de código, convenciones de nombres de ramas...',
+
+supportPlaceholder:
+  'Si este proyecto te resulta útil, considera apoyar su desarrollo:',
+};
+
+export default es;

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -1,0 +1,160 @@
+const fr = {
+  home: 'Accueil',
+  readmeMaker: 'Créateur README',
+  howToUse: 'Comment Utiliser',
+  source: 'Source',
+
+  projectTitle: 'Titre du Projet et Badges',
+  projectName: 'NOM DU PROJET *',
+  tagline: 'SLOGAN',
+  githubUser: 'UTILISATEUR GITHUB',
+  repoName: 'NOM DU DÉPÔT',
+
+  description: 'Description',
+  features: 'Fonctionnalités',
+  techStack: 'Pile Technologique',
+
+  installation: 'Installation',
+prerequisites: 'PRÉREQUIS',
+installCommands: 'COMMANDES D’INSTALLATION (une par ligne)',
+envVariables: 'VARIABLES D’ENVIRONNEMENT (optionnel)',
+runCommand: 'COMMANDE D’EXÉCUTION / INSTRUCTIONS',
+
+word: 'Mot',
+words: 'Mots',
+
+autoBadges: 'BADGES AUTOMATIQUES — cliquez pour activer/désactiver',
+
+shortDescription: 'DESCRIPTION COURTE',
+
+projectProblem:
+  'Que fait votre projet ? Quel problème résout-il ?',
+
+awesomeProject: 'ProjetIncroyable',
+
+blazingFast: 'Un outil ultra-rapide pour...',
+
+octocat: 'octocat',
+
+awesomeRepo: 'projet-incroyable',
+
+installation: 'Installation',
+
+prerequisites: 'PRÉREQUIS',
+
+installCommands: 'COMMANDES D’INSTALLATION (une par ligne)',
+
+envVariables: 'VARIABLES D’ENVIRONNEMENT (optionnel)',
+
+runCommand: 'COMMANDE D’EXÉCUTION / INSTRUCTIONS D’UTILISATION',
+
+templates: 'Modèles',
+sections: 'Sections',
+
+webApp: 'Application Web',
+mlAi: 'ML / IA',
+backendApi: 'API Backend',
+cliTool: 'Outil CLI',
+academicResearch: 'Académique / Recherche',
+mobileApp: 'Application Mobile',
+library: 'Bibliothèque',
+hackathon: 'Hackathon',
+openSource: 'Open Source',
+
+academicDetails: 'Détails académiques / recherche',
+abstract: 'RÉSUMÉ',
+paperLink: 'LIEN DU PAPIER',
+datasetAccess: 'ACCÈS AU DATASET',
+methodology: 'MÉTHODOLOGIE',
+citations: 'CITATIONS / BIBTEX',
+
+keyFeatures:
+  'FONCTIONNALITÉS PRINCIPALES — utilisez "### Category" pour les groupes et "- item" pour les listes',
+
+selectStack: 'CLIQUEZ POUR SÉLECTIONNER VOTRE STACK',
+customTech: 'OU AJOUTEZ UN STACK PERSONNALISÉ (séparé par des virgules)',
+
+projectStructure: 'Visualiseur de structure du projet',
+folderStructure:
+  'COLLEZ LA STRUCTURE DE VOTRE DOSSIER (indentée avec des espaces)',
+visualPreview: 'APERÇU VISUEL',
+structurePreview:
+  'Collez la structure ci-dessus pour voir un aperçu...',
+
+screenshots: 'Captures d’écran',
+videoLink: 'LIEN DE DÉMO / VIDÉO (optionnel)',
+dragScreenshots: 'GLISSER-DÉPOSER LES CAPTURES D’ÉCRAN',
+dropImages:
+  'Déposez les images ici ou cliquez pour parcourir',
+imageFormats:
+  'PNG, JPG, GIF — ils seront liés en Markdown',
+imageUrls:
+  'OU AJOUTEZ DES URL D’IMAGES (format : Label | URL, une par ligne)',
+
+apiDocs: 'Documentation API',
+apiEndpoints:
+  'API ENDPOINTS — format : METHOD /path | Description (une par ligne)',
+apiBaseUrl: 'URL DE BASE API (optionnel)',
+
+contributing: 'Contribution',
+contributingNotes:
+  'NOTES DE CONTRIBUTION PERSONNALISÉES (optionnel — guide généré automatiquement)',
+
+licenseAuthor: 'Licence & Auteur',
+license: 'LICENCE',
+fullName: 'NOM COMPLET',
+githubUsername: "NOM D'UTILISATEUR GITHUB",
+email: 'EMAIL (optionnel)',
+linkedin: 'LINKEDIN (optionnel)',
+portfolio: 'PORTFOLIO (optionnel)',
+
+supportDonation: 'Support & Don',
+supportMessage: 'MESSAGE DE SUPPORT (optionnel)',
+buyMeCoffee: 'BUY ME A COFFEE (nom utilisateur)',
+kofi: 'KO-FI (nom utilisateur)',
+patreon: 'PATREON (nom utilisateur)',
+githubSponsors: 'GITHUB SPONSORS (nom utilisateur)',
+
+liveDemoUrl: 'URL DE DÉMO EN DIRECT (optionnel)',
+
+abstractPlaceholder:
+  'Résumez le problème de recherche, l’approche et les principaux résultats.',
+
+methodologyPlaceholder:
+  '### Collecte des Données\n- Décrivez la source et le prétraitement des données\n\n### Expériences\n- Décrivez le modèle, les bases de référence et les métriques d’évaluation',
+
+citationPlaceholder:
+  '@article{yourpaper2026,\n  title={Titre de votre article},\n  author={Premier Auteur et Deuxième Auteur},\n  journal={Conférence ou Journal},\n  year={2026}\n}',
+
+featuresPlaceholder:
+  '### 🔐 Authentification\n- Vérification OTP par email\n- Connexion / déconnexion sécurisée\n\n### 📝 Publications\n- Créer, Lire, Mettre à jour, Supprimer',
+
+prerequisitesPlaceholder:
+  'Python 3.10+, Node.js 18+',
+
+installPlaceholder:
+  'git clone https://github.com/user/repo.git\ncd repo\npip install -r requirements.txt',
+
+envPlaceholder:
+  'SECRET_KEY=your_secret\nDATABASE_URL=sqlite:///db.sqlite3',
+
+runPlaceholder:
+  'python manage.py runserver\n\n# Ensuite ouvrez http://127.0.0.1:8000/',
+
+structurePlaceholder:
+  'src/\n  api/\n  models/\n  utils/\ntemplates/\nmain.py\nrequirements.txt',
+
+imageUrlPlaceholder:
+  'Page d’accueil | https://i.imgur.com/abc.png\nTableau de bord | https://i.imgur.com/xyz.png',
+
+apiPlaceholder:
+  'GET /api/users | Obtenir tous les utilisateurs\nPOST /api/users | Créer un nouvel utilisateur',
+
+contributingPlaceholder:
+  'Toutes directives spécifiques, règles de style de code, conventions de nommage des branches...',
+
+supportPlaceholder:
+  'Si ce projet vous est utile, envisagez de soutenir son développement :',
+};
+
+export default fr;

--- a/src/i18n/hi.js
+++ b/src/i18n/hi.js
@@ -1,0 +1,158 @@
+const hi = {
+  home: 'होम',
+  readmeMaker: 'README मेकर',
+  howToUse: 'कैसे उपयोग करें',
+  source: 'सोर्स',
+
+  projectTitle: 'प्रोजेक्ट शीर्षक और बैज',
+  projectName: 'प्रोजेक्ट नाम *',
+  tagline: 'टैगलाइन',
+  githubUser: 'गिटहब उपयोगकर्ता',
+  repoName: 'रिपॉजिटरी नाम',
+
+  description: 'विवरण',
+  features: 'विशेषताएँ',
+  techStack: 'टेक स्टैक',
+
+  installation: 'इंस्टॉलेशन',
+prerequisites: 'पूर्व आवश्यकताएँ',
+installCommands: 'इंस्टॉल कमांड (प्रति पंक्ति एक)',
+envVariables: 'एनवायरनमेंट वेरिएबल्स (वैकल्पिक)',
+runCommand: 'रन कमांड / उपयोग निर्देश',
+
+word: 'शब्द',
+words: 'शब्द',
+
+autoBadges: 'ऑटो बैज — टॉगल करने के लिए क्लिक करें',
+
+shortDescription: 'संक्षिप्त विवरण',
+
+projectProblem:
+  'आपका प्रोजेक्ट क्या करता है? यह किस समस्या को हल करता है?',
+
+awesomeProject: 'शानदारप्रोजेक्ट',
+
+blazingFast: 'एक बेहद तेज़ टूल...',
+
+octocat: 'octocat',
+
+awesomeRepo: 'शानदार-प्रोजेक्ट',
+
+installation: 'इंस्टॉलेशन',
+
+prerequisites: 'पूर्व आवश्यकताएँ',
+
+installCommands: 'इंस्टॉल कमांड्स (प्रति लाइन एक)',
+
+envVariables: 'एनवायरनमेंट वेरिएबल्स (वैकल्पिक)',
+
+runCommand: 'रन कमांड / उपयोग निर्देश',
+
+templates: 'टेम्पलेट्स',
+sections: 'सेक्शन्स',
+
+webApp: 'वेब ऐप',
+mlAi: 'एमएल / एआई',
+backendApi: 'बैकएंड API',
+cliTool: 'CLI टूल',
+academicResearch: 'शैक्षणिक / रिसर्च',
+mobileApp: 'मोबाइल ऐप',
+library: 'लाइब्रेरी',
+hackathon: 'हैकाथॉन',
+openSource: 'ओपन सोर्स',
+
+academicDetails: 'शैक्षणिक / शोध विवरण',
+abstract: 'सारांश',
+paperLink: 'पेपर लिंक',
+datasetAccess: 'डेटासेट एक्सेस',
+methodology: 'कार्यप्रणाली',
+citations: 'संदर्भ / BIBTEX',
+
+keyFeatures:
+  'मुख्य विशेषताएँ — समूहों के लिए "### Category", बुलेट्स के लिए "- item" का उपयोग करें',
+
+selectStack: 'अपना स्टैक चुनने के लिए क्लिक करें',
+customTech: 'या कस्टम जोड़ें (कॉमा से अलग करें)',
+
+projectStructure: 'प्रोजेक्ट संरचना विज़ुअलाइज़र',
+folderStructure:
+  'अपनी फ़ोल्डर संरचना पेस्ट करें (स्पेस से इंडेंट करें)',
+visualPreview: 'दृश्य पूर्वावलोकन',
+structurePreview: 'पूर्वावलोकन देखने के लिए ऊपर संरचना पेस्ट करें...',
+
+screenshots: 'स्क्रीनशॉट्स',
+videoLink: 'लाइव डेमो / वीडियो लिंक (वैकल्पिक)',
+dragScreenshots: 'स्क्रीनशॉट्स ड्रैग और ड्रॉप करें',
+dropImages: 'चित्र यहाँ छोड़ें या ब्राउज़ करने के लिए क्लिक करें',
+imageFormats:
+  'PNG, JPG, GIF — इन्हें Markdown के रूप में लिंक किया जाएगा',
+imageUrls:
+  'या इमेज URL जोड़ें (फॉर्मेट: Label | URL, प्रत्येक लाइन में एक)',
+
+apiDocs: 'API दस्तावेज़ीकरण',
+apiEndpoints:
+  'API ENDPOINTS — फॉर्मेट: METHOD /path | विवरण (प्रत्येक लाइन में एक)',
+apiBaseUrl: 'API बेस URL (वैकल्पिक)',
+
+contributing: 'योगदान',
+contributingNotes:
+  'कस्टम योगदान नोट्स (वैकल्पिक — डिफ़ॉल्ट गाइड स्वतः बनेगी)',
+
+licenseAuthor: 'लाइसेंस और लेखक',
+license: 'लाइसेंस',
+fullName: 'पूरा नाम',
+githubUsername: 'GITHUB उपयोगकर्ता नाम',
+email: 'ईमेल (वैकल्पिक)',
+linkedin: 'लिंक्डइन (वैकल्पिक)',
+portfolio: 'पोर्टफोलियो (वैकल्पिक)',
+
+supportDonation: 'सहायता और दान',
+supportMessage: 'सहायता संदेश (वैकल्पिक)',
+buyMeCoffee: 'BUY ME A COFFEE (यूज़रनेम)',
+kofi: 'KO-FI (यूज़रनेम)',
+patreon: 'PATREON (यूज़रनेम)',
+githubSponsors: 'GITHUB SPONSORS (यूज़रनेम)',
+
+liveDemoUrl: 'लाइव डेमो URL (वैकल्पिक)',
+
+abstractPlaceholder:
+  'अनुसंधान समस्या, दृष्टिकोण और मुख्य निष्कर्षों का सारांश लिखें।',
+
+methodologyPlaceholder:
+  '### डेटा संग्रह\n- डेटासेट स्रोत और प्रीप्रोसेसिंग का वर्णन करें\n\n### प्रयोग\n- मॉडल, बेसलाइन और मूल्यांकन मेट्रिक्स का वर्णन करें',
+
+citationPlaceholder:
+  '@article{yourpaper2026,\n  title={आपके शोधपत्र का शीर्षक},\n  author={पहला लेखक और दूसरा लेखक},\n  journal={सम्मेलन या जर्नल},\n  year={2026}\n}',
+
+featuresPlaceholder:
+  '### 🔐 प्रमाणीकरण\n- ईमेल OTP सत्यापन\n- सुरक्षित लॉगिन / लॉगआउट\n\n### 📝 पोस्ट्स\n- बनाएं, पढ़ें, अपडेट करें, हटाएं',
+
+prerequisitesPlaceholder:
+  'Python 3.10+, Node.js 18+',
+
+installPlaceholder:
+  'git clone https://github.com/user/repo.git\ncd repo\npip install -r requirements.txt',
+
+envPlaceholder:
+  'SECRET_KEY=your_secret\nDATABASE_URL=sqlite:///db.sqlite3',
+
+runPlaceholder:
+  'python manage.py runserver\n\n# फिर http://127.0.0.1:8000/ खोलें',
+
+structurePlaceholder:
+  'src/\n  api/\n  models/\n  utils/\ntemplates/\nmain.py\nrequirements.txt',
+
+imageUrlPlaceholder:
+  'लैंडिंग पेज | https://i.imgur.com/abc.png\nडैशबोर्ड | https://i.imgur.com/xyz.png',
+
+apiPlaceholder:
+  'GET /api/users | सभी उपयोगकर्ताओं को प्राप्त करें\nPOST /api/users | नया उपयोगकर्ता बनाएं',
+
+contributingPlaceholder:
+  'कोई विशेष दिशानिर्देश, कोड स्टाइल नियम, ब्रांच नामकरण नियम...',
+
+supportPlaceholder:
+  'यदि यह प्रोजेक्ट आपके लिए उपयोगी है, तो कृपया इसके विकास का समर्थन करने पर विचार करें:',
+};
+
+export default hi;

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,13 @@
+import en from "./en";
+import hi from "./hi";
+import es from "./es";
+import fr from "./fr";
+import zh from "./zh";
+
+export const translations = {
+  en,
+  hi,
+  es,
+  fr,
+  zh,
+};

--- a/src/i18n/zh.js
+++ b/src/i18n/zh.js
@@ -1,0 +1,160 @@
+const zh = {
+  home: '首页',
+  readmeMaker: 'README 生成器',
+  howToUse: '使用方法',
+  source: '源码',
+
+  projectTitle: '项目标题和徽章',
+  projectName: '项目名称 *',
+  tagline: '标语',
+  githubUser: 'GitHub 用户',
+  repoName: '仓库名称',
+
+  description: '描述',
+  features: '功能',
+  techStack: '技术栈',
+
+  installation: '安装',
+prerequisites: '先决条件',
+installCommands: '安装命令（每行一个）',
+envVariables: '环境变量（可选）',
+runCommand: '运行命令 / 使用说明',
+
+word: '词',
+words: '词',
+
+autoBadges: '自动徽章 — 点击切换',
+
+shortDescription: '简短描述',
+
+projectProblem:
+  '你的项目是做什么的？它解决了什么问题？',
+
+awesomeProject: '超棒项目',
+
+blazingFast: '一个极速工具，用于...',
+
+octocat: 'octocat',
+
+awesomeRepo: 'awesome-project',
+
+installation: '安装',
+
+prerequisites: '前置要求',
+
+installCommands: '安装命令（每行一个）',
+
+envVariables: '环境变量（可选）',
+
+runCommand: '运行命令 / 使用说明',
+
+templates: '模板',
+sections: '部分',
+
+webApp: '网页应用',
+mlAi: '机器学习 / AI',
+backendApi: '后端 API',
+cliTool: 'CLI 工具',
+academicResearch: '学术 / 研究',
+mobileApp: '移动应用',
+library: '库',
+hackathon: '黑客松',
+openSource: '开源',
+
+academicDetails: '学术 / 研究详情',
+abstract: '摘要',
+paperLink: '论文链接',
+datasetAccess: '数据集访问',
+methodology: '方法论',
+citations: '引用 / BIBTEX',
+
+keyFeatures:
+  '主要功能 — 使用 "### Category" 创建分组，使用 "- item" 创建列表',
+
+selectStack: '点击选择你的技术栈',
+customTech: '或添加自定义技术（用逗号分隔）',
+
+projectStructure: '项目结构可视化',
+folderStructure:
+  '粘贴你的文件夹结构（使用空格缩进）',
+visualPreview: '可视化预览',
+structurePreview:
+  '在上方粘贴结构以查看预览...',
+
+screenshots: '截图',
+videoLink: '在线演示 / 视频链接（可选）',
+dragScreenshots: '拖放截图',
+dropImages:
+  '将图片拖到这里或点击浏览',
+imageFormats:
+  'PNG、JPG、GIF — 它们将以 Markdown 链接形式显示',
+imageUrls:
+  '或添加图片 URL（格式：Label | URL，每行一个）',
+
+apiDocs: 'API 文档',
+apiEndpoints:
+  'API ENDPOINTS — 格式：METHOD /path | 描述（每行一个）',
+apiBaseUrl: 'API 基础 URL（可选）',
+
+contributing: '贡献',
+contributingNotes:
+  '自定义贡献说明（可选 — 默认指南将自动生成）',
+
+licenseAuthor: '许可证与作者',
+license: '许可证',
+fullName: '全名',
+githubUsername: 'GITHUB 用户名',
+email: '邮箱（可选）',
+linkedin: 'LINKEDIN（可选）',
+portfolio: '作品集（可选）',
+
+supportDonation: '支持与捐赠',
+supportMessage: '支持信息（可选）',
+buyMeCoffee: 'BUY ME A COFFEE（用户名）',
+kofi: 'KO-FI（用户名）',
+patreon: 'PATREON（用户名）',
+githubSponsors: 'GITHUB SPONSORS（用户名）',
+
+liveDemoUrl: '在线演示 URL（可选）',
+
+abstractPlaceholder:
+  '总结研究问题、方法以及主要成果。',
+
+methodologyPlaceholder:
+  '### 数据收集\n- 描述数据集来源和预处理\n\n### 实验\n- 描述模型、基线方法和评估指标',
+
+citationPlaceholder:
+  '@article{yourpaper2026,\n  title={你的论文标题},\n  author={第一作者 和 第二作者},\n  journal={会议或期刊},\n  year={2026}\n}',
+
+featuresPlaceholder:
+  '### 🔐 身份验证\n- 邮箱 OTP 验证\n- 安全登录 / 登出\n\n### 📝 帖子\n- 创建、读取、更新、删除',
+
+prerequisitesPlaceholder:
+  'Python 3.10+, Node.js 18+',
+
+installPlaceholder:
+  'git clone https://github.com/user/repo.git\ncd repo\npip install -r requirements.txt',
+
+envPlaceholder:
+  'SECRET_KEY=your_secret\nDATABASE_URL=sqlite:///db.sqlite3',
+
+runPlaceholder:
+  'python manage.py runserver\n\n# 然后打开 http://127.0.0.1:8000/',
+
+structurePlaceholder:
+  'src/\n  api/\n  models/\n  utils/\ntemplates/\nmain.py\nrequirements.txt',
+
+imageUrlPlaceholder:
+  '首页 | https://i.imgur.com/abc.png\n仪表盘 | https://i.imgur.com/xyz.png',
+
+apiPlaceholder:
+  'GET /api/users | 获取所有用户\nPOST /api/users | 创建新用户',
+
+contributingPlaceholder:
+  '任何特定指南、代码风格规则、分支命名规范...',
+
+supportPlaceholder:
+  '如果这个项目对你有帮助，请考虑支持它的开发：',
+};
+
+export default zh;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,8 +3,12 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/index.css';
 
+import { LanguageProvider } from './context/LanguageContext';
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <LanguageProvider>
+      <App />
+    </LanguageProvider>
   </React.StrictMode>
 );

--- a/src/pages/ReadmeMaker/EditorPanel.jsx
+++ b/src/pages/ReadmeMaker/EditorPanel.jsx
@@ -1,14 +1,17 @@
 import { useRef } from 'react';
 import { TECHS, BADGES } from '../../utils/constants';
 import { convertStructure } from '../../utils/structureUtils';
+import { useTranslation } from '../../hooks/useTranslation';
 import { getWordCount } from '../../utils/markdownUtils';
 
-function WordCount({ text }) {
+function WordCount({ text ,t}) {
   const count = getWordCount(text);
   return (
     <label>
       <span className="wordCount">{count}</span>{' '}
-      <span className="wordCountText">{count === 1 ? 'Word' : 'Words'}</span>
+      <span className="wordCountText">
+  {count === 1 ? t.word : t.words}
+</span>
     </label>
   );
 }
@@ -36,10 +39,11 @@ export default function EditorPanel({
 }) {
   const fileInputRef = useRef(null);
   const dropZoneRef = useRef(null);
+  const t = useTranslation();
 
   const structPreview = formData.rawStructure
     ? convertStructure(formData.rawStructure, formData.projName || 'project')
-    : 'Paste structure above to preview...';
+    : t.structurePreview;
 
   const techCount = selectedTechs.size;
 
@@ -60,33 +64,37 @@ export default function EditorPanel({
     <div className="editor">
       <div className="editor-inner" id="editorInner">
 
-        <EditorSection num={1} title="Project Title & Badges" hidden={!sectionState.title}>
+        <EditorSection
+  num={1}
+  title={t.projectTitle}
+  hidden={!sectionState.title}
+>
           <div className="two-col">
             <div>
-              <label>PROJECT NAME *</label>
-              <input type="text" id="projName" placeholder="AwesomeProject"
+              <label>{t.projectName}</label>
+              <input type="text" id="projName" placeholder={t.awesomeProject}
                 value={formData.projName} onChange={e => updateField('projName', e.target.value)} />
             </div>
             <div>
-              <label>TAGLINE</label>
-              <input type="text" id="tagline" placeholder="A blazing-fast tool for..."
+              <label>{t.tagline}</label>
+              <input type="text" id="tagline" placeholder={t.blazingFast}
                 value={formData.tagline} onChange={e => updateField('tagline', e.target.value)} />
             </div>
           </div>
           <div className="two-col">
             <div>
-              <label>GITHUB USER</label>
-              <input type="text" id="ghUser" placeholder="octocat"
+              <label>{t.githubUser}</label>
+              <input type="text" id="ghUser" placeholder={t.octocat}
                 value={formData.ghUser} onChange={e => updateField('ghUser', e.target.value)} />
             </div>
             <div>
-              <label>REPO NAME</label>
-              <input type="text" id="repoSlug" placeholder="awesome-project"
+              <label>{t.repoName}</label>
+              <input type="text" id="repoSlug" placeholder={t.awesomeRepo}
                 value={formData.repoSlug} onChange={e => updateField('repoSlug', e.target.value)} />
             </div>
           </div>
           <div>
-            <label>AUTO BADGES — click to toggle</label>
+            <label>{t.autoBadges}</label>
             <div className="badge-picker">
               {BADGES.map(b => (
                 <button
@@ -101,143 +109,157 @@ export default function EditorPanel({
           </div>
         </EditorSection>
 
-        <EditorSection num={2} title="Description" hidden={!sectionState.description}>
+        <EditorSection
+  num={2}
+  title={t.description}
+  hidden={!sectionState.description}
+>
           <div>
-            <label>SHORT DESCRIPTION</label>
+            <label>{t.shortDescription}</label>
             <textarea className="textInput" id="description" style={{ minHeight: 90 }}
-              placeholder="What does your project do? What problem does it solve?"
+              placeholder={t.projectProblem}
               value={formData.description} onChange={e => updateField('description', e.target.value)} />
-            <WordCount text={formData.description} />
+            <WordCount text={formData.description} t={t}/>
           </div>
           <div>
-            <label>LIVE DEMO URL (optional)</label>
+            <label>{t.liveDemoUrl}</label>
             <input type="url" id="demoUrl" placeholder="https://yourapp.com"
               value={formData.demoUrl} onChange={e => updateField('demoUrl', e.target.value)} />
           </div>
         </EditorSection>
 
-        <EditorSection num="3A" title="Academic / Research Details" hidden={!sectionState.academic}>
+        <EditorSection num="3A" title={t.academicDetails} hidden={!sectionState.academic}>
           <div>
-            <label>ABSTRACT</label>
+            <label>{t.abstract}</label>
             <textarea className="textInput" id="abstractText" style={{ minHeight: 100 }}
-              placeholder="Summarize the research problem, approach, and key findings."
+              placeholder={t.abstractPlaceholder}
               value={formData.abstractText} onChange={e => updateField('abstractText', e.target.value)} />
-            <WordCount text={formData.abstractText} />
+            <WordCount text={formData.abstractText} t={t}/>
           </div>
           <div className="two-col">
             <div>
-              <label>PAPER LINK</label>
+              <label>{t.paperLink}</label>
               <input type="url" id="paperLink" placeholder="https://arxiv.org/abs/..."
                 value={formData.paperLink} onChange={e => updateField('paperLink', e.target.value)} />
             </div>
             <div>
-              <label>DATASET ACCESS</label>
+              <label>{t.datasetAccess}</label>
               <input type="url" id="datasetLink" placeholder="https://doi.org/... or https://huggingface.co/datasets/..."
                 value={formData.datasetLink} onChange={e => updateField('datasetLink', e.target.value)} />
             </div>
           </div>
           <div>
-            <label>METHODOLOGY</label>
+            <label>{t.methodology}</label>
             <textarea className="textInput" id="methodology" style={{ minHeight: 100 }}
-              placeholder={'### Data Collection\n- Describe dataset source and preprocessing\n\n### Experiments\n- Describe model, baselines, and evaluation metrics'}
+              placeholder={t.methodologyPlaceholder}
               value={formData.methodology} onChange={e => updateField('methodology', e.target.value)} />
-            <WordCount text={formData.methodology} />
+            <WordCount text={formData.methodology} t={t}/>
           </div>
           <div>
-            <label>CITATIONS / BIBTEX</label>
+            <label>{t.citations}</label>
             <textarea className="textInput" id="bibtexCitation" style={{ minHeight: 120 }}
-              placeholder={'@article{yourpaper2026,\n  title={Your Paper Title},\n  author={First Author and Second Author},\n  journal={Conference or Journal},\n  year={2026}\n}'}
+              placeholder={t.citationPlaceholder}
               value={formData.bibtexCitation} onChange={e => updateField('bibtexCitation', e.target.value)} />
-            <WordCount text={formData.bibtexCitation} />
-          </div>
-        </EditorSection>
-
-        <EditorSection num={3} title="Features" hidden={!sectionState.features}>
-          <div>
-            <label>KEY FEATURES — use "### Category" for groups, "- item" for bullets</label>
-            <textarea className="textInput" id="features" style={{ minHeight: 130 }}
-              placeholder={'### 🔐 Authentication\n- Email OTP verification\n- Secure login / logout\n\n### 📝 Posts\n- Create, Read, Update, Delete'}
-              value={formData.features} onChange={e => updateField('features', e.target.value)} />
-            <WordCount text={formData.features} />
+            <WordCount text={formData.bibtexCitation} t={t}/>
           </div>
         </EditorSection>
 
         <EditorSection
-          num={4} title="Tech Stack" hidden={!sectionState.techstack}
+  num={3}
+  title={t.features}
+  hidden={!sectionState.features}
+>
+          <div>
+            <label>{t.keyFeatures}</label>
+            <textarea className="textInput" id="features" style={{ minHeight: 130 }}
+              placeholder={t.featuresPlaceholder}
+              value={formData.features} onChange={e => updateField('features', e.target.value)} />
+            <WordCount text={formData.features} t={t}/>
+          </div>
+        </EditorSection>
+
+        <EditorSection
+  num={4}
+  title={t.techStack}
+  hidden={!sectionState.techstack}
           badge={techCount > 0 ? `${techCount} selected` : undefined}
         >
           <div>
-            <label>CLICK TO SELECT YOUR STACK</label>
+            <label>{t.selectStack}</label>
             <div className="tech-picker">
-              {TECHS.map(t => (
+              {TECHS.map(tech => (
                 <button
-                  key={t.label}
-                  className={`tech-chip${selectedTechs.has(t.label) ? ' selected' : ''}`}
-                  onClick={() => toggleTech(t.label)}
+                  key={tech.label}
+                  className={`tech-chip${selectedTechs.has(tech.label) ? ' selected' : ''}`}
+                  onClick={() => toggleTech(tech.label)}
                 >
-                  <span className="emoji">{t.emoji}</span>{t.label}
+                  <span className="emoji">{tech.emoji}</span>{tech.label}
                 </button>
               ))}
             </div>
           </div>
           <div>
-            <label>OR ADD CUSTOM (comma separated)</label>
+            <label>{t.customTech}</label>
             <input type="text" id="customTech" placeholder="Celery, Redis, Nginx..."
               value={formData.customTech} onChange={e => updateField('customTech', e.target.value)} />
           </div>
         </EditorSection>
 
-        <EditorSection num={5} title="Installation" hidden={!sectionState.installation}>
+        <EditorSection
+  num={5}
+  title={t.installation}
+  hidden={!sectionState.installation}
+>
           <div>
-            <label>PREREQUISITES</label>
-            <input type="text" id="prereqs" placeholder="Python 3.10+, Node.js 18+"
+            <label>{t.prerequisites}</label>
+            <input type="text" id="prereqs" placeholder={t.prerequisitesPlaceholder}
               value={formData.prereqs} onChange={e => updateField('prereqs', e.target.value)} />
           </div>
           <div>
-            <label>INSTALL COMMANDS (one per line)</label>
+            <label>{t.installCommands}</label>
             <textarea className="textInput" id="installCmds" style={{ minHeight: 100 }}
-              placeholder={'git clone https://github.com/user/repo.git\ncd repo\npip install -r requirements.txt'}
+              placeholder={t.installPlaceholder}
               value={formData.installCmds} onChange={e => updateField('installCmds', e.target.value)} />
-            <WordCount text={formData.installCmds} />
+            <WordCount text={formData.installCmds} t={t}/>
           </div>
           <div>
-            <label>ENV VARIABLES (optional)</label>
+            <label>{t.envVariables}</label>
             <textarea className="textInput" id="envVars" style={{ minHeight: 70 }}
-              placeholder={'SECRET_KEY=your_secret\nDATABASE_URL=sqlite:///db.sqlite3'}
+              placeholder={t.envPlaceholder}
               value={formData.envVars} onChange={e => updateField('envVars', e.target.value)} />
-            <WordCount text={formData.envVars} />
+            <WordCount text={formData.envVars} t={t}/>
           </div>
           <div>
-            <label>RUN COMMAND / USAGE INSTRUCTIONS</label>
+            <label>{t.runCommand}</label>
             <textarea className="textInput" id="usageCmd" style={{ minHeight: 80 }}
-              placeholder={'python manage.py runserver\n\n# Then open http://127.0.0.1:8000/'}
+              placeholder={t.runPlaceholder}
               value={formData.usageCmd} onChange={e => updateField('usageCmd', e.target.value)} />
-            <WordCount text={formData.usageCmd} />
+            <WordCount text={formData.usageCmd} t={t}/>
           </div>
         </EditorSection>
 
-        <EditorSection num={7} title="Project Structure Visualizer" hidden={!sectionState.structure}>
+        <EditorSection num={7} title={t.projectStructure} hidden={!sectionState.structure}>
           <div>
-            <label>PASTE YOUR FOLDER STRUCTURE (indented with spaces)</label>
+            <label>{t.folderStructure}</label>
             <textarea className="textInput" id="rawStructure" style={{ minHeight: 120 }}
-              placeholder={'src/\n  api/\n  models/\n  utils/\ntemplates/\nmain.py\nrequirements.txt'}
+              placeholder={t.structurePlaceholder}
               value={formData.rawStructure} onChange={e => updateField('rawStructure', e.target.value)} />
-            <WordCount text={formData.rawStructure} />
+            <WordCount text={formData.rawStructure} t={t}/>
           </div>
           <div>
-            <label>VISUAL PREVIEW</label>
+            <label>{t.visualPreview}</label>
             <div className="struct-preview">{structPreview}</div>
           </div>
         </EditorSection>
 
-        <EditorSection num={8} title="Screenshots" hidden={!sectionState.screenshots}>
+        <EditorSection num={8} title={t.screenshots} hidden={!sectionState.screenshots}>
           <div>
-            <label>LIVE DEMO / VIDEO LINK (optional)</label>
+            <label>{t.videoLink}</label>
             <input type="url" id="videoUrl" placeholder="https://youtube.com/watch?v=..."
               value={formData.videoUrl} onChange={e => updateField('videoUrl', e.target.value)} />
           </div>
           <div>
-            <label>DRAG &amp; DROP SCREENSHOTS</label>
+            <label>{t.dragScreenshots}</label>
             <div
               ref={dropZoneRef}
               className="drop-zone"
@@ -247,8 +269,8 @@ export default function EditorPanel({
               onClick={() => fileInputRef.current?.click()}
             >
               <div className="drop-zone-icon">🖼️</div>
-              <p>Drop images here or click to browse</p>
-              <small>PNG, JPG, GIF — they'll be linked as Markdown</small>
+              <p>{t.dropImages}</p>
+              <small>{t.imageFormats}</small>
               <input
                 ref={fileInputRef}
                 type="file"
@@ -269,43 +291,43 @@ export default function EditorPanel({
             </div>
           </div>
           <div>
-            <label>OR ADD IMAGE URLS (format: Label | URL, one per line)</label>
+            <label>{t.imageUrls}</label>
             <textarea className="textInput" id="imageUrls" style={{ minHeight: 60 }}
-              placeholder={'Landing Page | https://i.imgur.com/abc.png\nDashboard | https://i.imgur.com/xyz.png'}
+              placeholder={t.imageUrlPlaceholder}
               value={formData.imageUrls} onChange={e => updateField('imageUrls', e.target.value)} />
-            <WordCount text={formData.imageUrls} />
+            <WordCount text={formData.imageUrls} t={t}/>
           </div>
         </EditorSection>
 
-        <EditorSection num={9} title="API Documentation" hidden={!sectionState.api}>
+        <EditorSection num={9} title={t.apiDocs} hidden={!sectionState.api}>
           <div>
-            <label>API ENDPOINTS — format: METHOD /path | Description (one per line)</label>
+            <label>{t.apiEndpoints}</label>
             <textarea className="textInput" id="apiDocs" style={{ minHeight: 100 }}
-              placeholder={'GET /api/users | Get all users\nPOST /api/users | Create a new user'}
+              placeholder={t.apiPlaceholder}
               value={formData.apiDocs} onChange={e => updateField('apiDocs', e.target.value)} />
-            <WordCount text={formData.apiDocs} />
+            <WordCount text={formData.apiDocs} t={t}/>
           </div>
           <div>
-            <label>API BASE URL (optional)</label>
+            <label>{t.apiBaseUrl}</label>
             <input type="text" id="apiBase" placeholder="https://api.yourapp.com/v1"
               value={formData.apiBase} onChange={e => updateField('apiBase', e.target.value)} />
           </div>
         </EditorSection>
 
-        <EditorSection num={10} title="Contributing" hidden={!sectionState.contributing}>
+        <EditorSection num={10} title={t.contributing} hidden={!sectionState.contributing}>
           <div>
-            <label>CUSTOM CONTRIBUTING NOTES (optional — default guide auto-generated)</label>
+            <label>{t.contributingNotes}</label>
             <textarea className="textInput" id="contribNotes" style={{ minHeight: 70 }}
-              placeholder="Any specific guidelines, code style rules, branch naming conventions..."
+              placeholder={t.contributingPlaceholder}
               value={formData.contribNotes} onChange={e => updateField('contribNotes', e.target.value)} />
-            <WordCount text={formData.contribNotes} />
+            <WordCount text={formData.contribNotes} t={t}/>
           </div>
         </EditorSection>
 
-        <EditorSection num={11} title="License & Author" hidden={!sectionState.author}>
+        <EditorSection num={11} title={t.licenseAuthor} hidden={!sectionState.author}>
           <div className="two-col">
             <div>
-              <label>LICENSE</label>
+              <label>{t.license}</label>
               <select id="license" value={formData.license} onChange={e => updateField('license', e.target.value)}>
                 <option value="MIT">MIT</option>
                 <option value="Apache-2.0">Apache 2.0</option>
@@ -318,65 +340,65 @@ export default function EditorPanel({
               </select>
             </div>
             <div>
-              <label>FULL NAME</label>
+              <label>{t.fullName}</label>
               <input type="text" id="authorName" placeholder="Your Name"
                 value={formData.authorName} onChange={e => updateField('authorName', e.target.value)} />
             </div>
           </div>
           <div className="two-col">
             <div>
-              <label>GITHUB USERNAME</label>
+              <label>{t.githubUsername}</label>
               <input type="text" id="authorGh" placeholder="username"
                 value={formData.authorGh} onChange={e => updateField('authorGh', e.target.value)} />
             </div>
             <div>
-              <label>EMAIL (optional)</label>
+              <label>{t.email}</label>
               <input type="email" id="authorEmail" placeholder="you@email.com"
                 value={formData.authorEmail} onChange={e => updateField('authorEmail', e.target.value)} />
             </div>
           </div>
           <div className="two-col">
             <div>
-              <label>LINKEDIN (optional)</label>
+              <label>{t.linkedin}</label>
               <input type="url" id="authorLinkedin" placeholder="https://linkedin.com/in/you"
                 value={formData.authorLinkedin} onChange={e => updateField('authorLinkedin', e.target.value)} />
             </div>
             <div>
-              <label>PORTFOLIO (optional)</label>
+              <label>{t.portfolio}</label>
               <input type="url" id="authorWebsite" placeholder="https://yoursite.com"
                 value={formData.authorWebsite} onChange={e => updateField('authorWebsite', e.target.value)} />
             </div>
           </div>
         </EditorSection>
 
-        <EditorSection num={12} title="Support & Donation" hidden={!sectionState.support}>
+        <EditorSection num={12} title={t.supportDonation} hidden={!sectionState.support}>
           <div>
-            <label>SUPPORT MESSAGE (optional)</label>
+            <label>{t.supportMessage}</label>
             <textarea className="textInput" id="supportMsg" style={{ minHeight: 60 }}
-              placeholder="If you find this project helpful, please consider supporting its development:"
+              placeholder={t.supportPlaceholder}
               value={formData.supportMsg} onChange={e => updateField('supportMsg', e.target.value)} />
-            <WordCount text={formData.supportMsg} />
+            <WordCount text={formData.supportMsg} t={t}/>
           </div>
           <div className="two-col">
             <div>
-              <label>BUY ME A COFFEE (username)</label>
+              <label>{t.buyMeCoffee}</label>
               <input type="text" id="supportBmac" placeholder="username"
                 value={formData.supportBmac} onChange={e => updateField('supportBmac', e.target.value)} />
             </div>
             <div>
-              <label>KO-FI (username)</label>
+              <label>{t.kofi}</label>
               <input type="text" id="supportKofi" placeholder="username"
                 value={formData.supportKofi} onChange={e => updateField('supportKofi', e.target.value)} />
             </div>
           </div>
           <div className="two-col">
             <div>
-              <label>PATREON (username)</label>
+              <label>{t.patreon}</label>
               <input type="text" id="supportPatreon" placeholder="username"
                 value={formData.supportPatreon} onChange={e => updateField('supportPatreon', e.target.value)} />
             </div>
             <div>
-              <label>GITHUB SPONSORS (username)</label>
+              <label>{t.githubSponsors}</label>
               <input type="text" id="supportGhSponsors" placeholder="username"
                 value={formData.supportGhSponsors} onChange={e => updateField('supportGhSponsors', e.target.value)} />
             </div>

--- a/src/pages/ReadmeMaker/Sidebar.jsx
+++ b/src/pages/ReadmeMaker/Sidebar.jsx
@@ -1,39 +1,41 @@
 import { SECTIONS, TECHS, TEMPLATES } from '../../utils/constants';
+import { useTranslation } from '../../hooks/useTranslation';
 
 export default function Sidebar({
   sectionState, toggleSection,
   selectedTechs, toggleTech,
   applyTemplate, activeTemplate,
 }) {
+  const t = useTranslation();
   const activeSectionCount = Object.values(sectionState).filter(Boolean).length;
 
   return (
     <aside className="sidebar">
       <div className="sidebar-section">
-        <div className="sidebar-label">Templates</div>
+        <div className="sidebar-label">{t.templates}</div>
         <div className="templates-grid">
-          {Object.entries(TEMPLATES).map(([key, t]) => (
+          {Object.entries(TEMPLATES).map(([key, template]) => (
             <button
               key={key}
               className={`template-btn${activeTemplate === key ? ' selected' : ''}`}
-              onClick={() => applyTemplate(t, key)}
+              onClick={() => applyTemplate(template, key)}
             >
-              {key === 'webapp' && '🌐 Web App'}
-              {key === 'ml' && '🤖 ML / AI'}
-              {key === 'api' && '⚡ Backend API'}
-              {key === 'cli' && '💻 CLI Tool'}
-              {key === 'academic' && '🎓 Academic / Research'}
-              {key === 'mobile' && '📱 Mobile App'}
-              {key === 'lib' && '📦 Library'}
-              {key === 'hackathon' && '🏆 Hackathon'}
-              {key === 'oss' && '🔓 Open Source'}
+              {key === 'webapp' && `🌐 ${t.webApp}`}
+              {key === 'ml' && `🤖 ${t.mlAi}`}
+              {key === 'api' && `⚡ ${t.backendApi}`}
+              {key === 'cli' && `💻 ${t.cliTool}`}
+              {key === 'academic' && `🎓 ${t.academicResearch}`}
+              {key === 'mobile' && `📱 ${t.mobileApp}`}
+              {key === 'lib' && `📦 ${t.library}`}
+              {key === 'hackathon' && `🏆 ${t.hackathon}`}
+              {key === 'oss' && `🔓 ${t.openSource}`}
             </button>
           ))}
         </div>
       </div>
 
       <div className="sidebar-section" style={{ flex: 1 }}>
-        <div className="sidebar-label">Sections</div>
+        <div className="sidebar-label">{t.sections}</div>
         <div className="section-toggles">
           {SECTIONS.map(sec => (
             <div


### PR DESCRIPTION
## Description

Added multilingual support to ReadmeForge using a centralized translation system.

This PR introduces:

* Language selector for switching UI languages
* Translation support for all major UI components
* JSON-based translation files for multiple languages
* Dynamic text rendering using `useTranslation`

Supported languages:

* English
* Hindi
* Spanish
* French
* Chinese

## Components Updated

* EditorPanel.jsx
* Sidebar.jsx
* Navbar.jsx
* LanguageSelector.jsx

## Changes Made

* Replaced hardcoded UI text with translation keys
* Added translation files for supported languages
* Integrated LanguageContext for global language management
* Added multilingual placeholders, labels, buttons, and helper text
<img width="1918" height="977" alt="image" src="https://github.com/user-attachments/assets/37789382-cb6e-4d38-8f9a-dffb299bc153" />
<img width="1915" height="857" alt="image" src="https://github.com/user-attachments/assets/2c16ca51-4514-4906-8ec5-ba2c3618b7f7" />

## Testing

* Verified language switching works correctly
* Checked translations across Navbar, Sidebar, and EditorPanel
* Confirmed no runtime errors during local testing

Closes #16
