### PR TITLE
fix: add URL validation for link fields in EditorPanel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **The fastest way to craft beautiful GitHub READMEs — no Markdown knowledge required.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Made with HTML](https://img.shields.io/badge/Made%20with-HTML%2FJS%2FCSS-orange.svg)](#)
+[![Built with React](https://img.shields.io/badge/Built%20with-React%20%2B%20Vite-blue.svg)](#)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 [ Live Demo](https://makeareadme.netlify.app) · [ Report a Bug](../../issues) · [Request a Feature](../../issues)
@@ -41,7 +41,7 @@
 
 ##  About
 
-**ReadmeForge** is a browser-based README generator that lets you build polished GitHub repository documentation in minutes — no Markdown expertise needed. Simply fill in your project's sections, toggle the content you want, upload screenshots, and watch a live preview update in real time. When you're done, copy the raw Markdown and paste it straight into your repo.
+**ReadmeForge** is a React-based README generator that lets you build polished GitHub repository documentation in minutes — no Markdown expertise needed. Simply fill in your project's sections, toggle the content you want, upload screenshots, and watch a live preview update in real time. When you're done, copy the raw Markdown and paste it straight into your repo.
 
 ---
 
@@ -52,7 +52,7 @@
 -  **Screenshot support** — Insert images directly into your README
 -  **One-click raw copy** — Grab the raw Markdown and paste it into GitHub instantly
 -  **Toggle sections** — Include only what your project needs
--  **Zero dependencies** — Pure HTML, CSS, and JavaScript; runs entirely in the browser
+-  **Modern React architecture** — Built using React + Vite for fast development and improved maintainability
 
 ---
 
@@ -68,7 +68,11 @@
 
 ### Prerequisites
 
-No installation required. ReadmeForge runs entirely in the browser.
+Before running locally, ensure you have:
+
+- Node.js (LTS recommended)
+- npm
+- Git
 
 ### Usage
 
@@ -77,20 +81,23 @@ No installation required. ReadmeForge runs entirely in the browser.
    git clone https://github.com/Mohit-368/readmeforge.git
    cd readmeforge
    ```
-
-2. **Open in your browser**
+2. **Install dependencies**
    ```bash
-   open index.html
-   # or simply double-click index.html
+   npm install
    ```
+3. **Start development server**
+   ```bash
+   npm run dev
+   ```
+4. **Open the local development URL shown in the terminal**
 
-3. **Build your README**
+5. **Build your README**
    - Fill in your project's details section by section
    - Toggle sections on/off as needed
    - Insert screenshots where relevant
    - Watch the live preview update in real time
 
-4. **Export**
+6. **Export**
    - Click **Copy Raw** to copy the generated Markdown
    - Paste it directly into your GitHub repository's `README.md`
 
@@ -98,13 +105,19 @@ No installation required. ReadmeForge runs entirely in the browser.
 
 ## 🗂️ Project Structure
 
+```text
+ReadmeForge/
+├── public/              # Static assets
+├── src/                 # Main React source code
+├── .gitignore           # Git ignored files
+├── eslint.config.js     # ESLint configuration
+├── index.html           # Root HTML template
+├── package.json         # Project dependencies and scripts
+├── package-lock.json    # Locked dependency versions
+├── vite.config.js       # Vite configuration
+└── README.md            # Project documentation
 ```
-readmeforge/
-├── index.html          # Main application entry point
-├── readmeforge.css     # Styling and layout
-├── readmeforge.js      # Core logic and preview generation
-└── README.md           # You are here
-```
+The application follows a React + Vite architecture for faster development, modular components, and improved maintainability.
 
 ---
 
@@ -146,9 +159,7 @@ Distributed under the MIT License. See [`LICENSE`](LICENSE) for more information
 
 ---
 
-
-
-Made with ❤️ using plain HTML, CSS & JavaScript
+Made with ❤️ using React, JavaScript & Vite
 
 ⭐ Star this repo if you found it useful!
 

--- a/readmeforge.css
+++ b/readmeforge.css
@@ -2437,4 +2437,16 @@ body.light-mode .gh-preview {
   .scroll-action {
     display: none !important;
   }
+/* URL Validation Styles */
+.input-url-invalid {
+  border: 2px solid #e74c3c !important;
+  outline: none !important;
+}
+
+.url-warning {
+  color: #e74c3c;
+  font-size: 0.75rem;
+  margin-top: 4px;
+  display: block;
+}
 }

--- a/src/hooks/useUrlValidation.js
+++ b/src/hooks/useUrlValidation.js
@@ -1,0 +1,9 @@
+export function isValidUrl(value) {
+  if (!value || !value.trim()) return true;
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/src/pages/ReadmeMaker/EditorPanel.jsx
+++ b/src/pages/ReadmeMaker/EditorPanel.jsx
@@ -1,3 +1,4 @@
+import { isValidUrl } from '../../hooks/useUrlValidation';
 import { useRef } from 'react';
 import { TECHS, BADGES } from '../../utils/constants';
 import { convertStructure } from '../../utils/structureUtils';
@@ -111,8 +112,12 @@ export default function EditorPanel({
           </div>
           <div>
             <label>LIVE DEMO URL (optional)</label>
-            <input type="url" id="demoUrl" placeholder="https://yourapp.com"
-              value={formData.demoUrl} onChange={e => updateField('demoUrl', e.target.value)} />
+             <input type="url" id="demoUrl" placeholder="https://yourapp.com"
+  value={formData.demoUrl} onChange={e => updateField('demoUrl', e.target.value)}
+  className={!isValidUrl(formData.demoUrl) ? 'input-url-invalid' : ''} />
+{!isValidUrl(formData.demoUrl) && (
+  <span className="url-warning">⚠️ Please enter a valid URL starting with https://</span>
+)}
           </div>
         </EditorSection>
 
@@ -234,7 +239,11 @@ export default function EditorPanel({
           <div>
             <label>LIVE DEMO / VIDEO LINK (optional)</label>
             <input type="url" id="videoUrl" placeholder="https://youtube.com/watch?v=..."
-              value={formData.videoUrl} onChange={e => updateField('videoUrl', e.target.value)} />
+  value={formData.videoUrl} onChange={e => updateField('videoUrl', e.target.value)}
+  className={!isValidUrl(formData.videoUrl) ? 'input-url-invalid' : ''} />
+{!isValidUrl(formData.videoUrl) && (
+  <span className="url-warning">⚠️ Please enter a valid URL starting with https://</span>
+)}
           </div>
           <div>
             <label>DRAG &amp; DROP SCREENSHOTS</label>
@@ -339,12 +348,20 @@ export default function EditorPanel({
             <div>
               <label>LINKEDIN (optional)</label>
               <input type="url" id="authorLinkedin" placeholder="https://linkedin.com/in/you"
-                value={formData.authorLinkedin} onChange={e => updateField('authorLinkedin', e.target.value)} />
+  value={formData.authorLinkedin} onChange={e => updateField('authorLinkedin', e.target.value)}
+  className={!isValidUrl(formData.authorLinkedin) ? 'input-url-invalid' : ''} />
+{!isValidUrl(formData.authorLinkedin) && (
+  <span className="url-warning">⚠️ Please enter a valid URL starting with https://</span>
+)}
             </div>
             <div>
               <label>PORTFOLIO (optional)</label>
               <input type="url" id="authorWebsite" placeholder="https://yoursite.com"
-                value={formData.authorWebsite} onChange={e => updateField('authorWebsite', e.target.value)} />
+  value={formData.authorWebsite} onChange={e => updateField('authorWebsite', e.target.value)}
+  className={!isValidUrl(formData.authorWebsite) ? 'input-url-invalid' : ''} />
+{!isValidUrl(formData.authorWebsite) && (
+  <span className="url-warning">⚠️ Please enter a valid URL starting with https://</span>
+)}
             </div>
           </div>
         </EditorSection>


### PR DESCRIPTION
Fixes #134

## Changes
- Created `src/hooks/useUrlValidation.js` with a reusable `isValidUrl()` function
- Added validation to Demo URL, Video URL, Author LinkedIn, and Author Website fields
- Shows a warning message ⚠️ when an invalid URL is entered
- Empty fields are allowed with no false warnings

## How to Test
1. Go to the README maker
2. Type `notaurl` in the Demo URL field
3. Warning message appears instantly
4. Type `https://example.com` — warning disappears