### PR TITLE
Feature/enhance how to use UI

### DIFF
--- a/src/pages/HowToUse/HowToUsePage.jsx
+++ b/src/pages/HowToUse/HowToUsePage.jsx
@@ -73,18 +73,34 @@ export default function HowToUsePage() {
         </section>
 
         <section className="htu-tips-section">
-          <div className="landing-container">
-            <h2 className="landing-section-title">Tips &amp; best practices</h2>
-            <div className="tips-grid">
-              {tips.map((t, i) => (
-                <div key={i} className="tip-card">
-                  <span className="tip-icon">{t.icon}</span>
-                  <p className="tip-text">{t.tip}</p>
-                </div>
-              ))}
-            </div>
+  <div className="landing-container">
+    <h2 className="landing-section-title">Tips &amp; best practices</h2>
+    <div className="terminal-box">
+      <div className="terminal-header">
+        <div className="terminal-dots">
+          <span className="terminal-dot terminal-dot--red"></span>
+          <span className="terminal-dot terminal-dot--yellow"></span>
+          <span className="terminal-dot terminal-dot--green"></span>
+        </div>
+        <span className="terminal-title">
+          <span className="terminal-prompt">$</span>
+        <span className="terminal-command">readme-tips.sh</span>
+        </span>
+      </div>
+      <div className="terminal-body">
+        {tips.map((t, i) => (
+          <div key={i} className="terminal-line">
+            <span className="terminal-num">
+              {String(i + 1).padStart(2, '0')}
+            </span>
+            <span className="terminal-icon">{t.icon}</span>
+            <span className="terminal-text">{t.tip}</span>
           </div>
-        </section>
+        ))}
+      </div>
+    </div>
+  </div>
+</section>
 
         <section className="htu-faq-section">
           <div className="landing-container">

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3340,48 +3340,101 @@ body.light-mode .gh-preview {
   border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
 }
+.terminal-box {
+  background: #0d1117;
+  border: 1px solid var(--accent);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow:
+    0 0 0 1px rgba(56,189,248,0.1),
+    0 0 24px rgba(56,189,248,0.15),
+    0 8px 32px rgba(0,0,0,0.4);
+}
+.terminal-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: #161b22;
+  border-bottom: 1px solid rgba(56,189,248,0.2);
+}
 
-.tips-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+.terminal-dots {
+  display: flex;
+  gap: 6px;
+}
+
+.terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.terminal-dot--red    { background: #ff5f57; }
+.terminal-dot--yellow { background: #ffbd2e; }
+.terminal-dot--green  { background: #28c840; }
+
+.terminal-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  letter-spacing: 0.5px;
+}
+
+.terminal-title .terminal-prompt {
+  color: #ffffff;
+  margin-right: 6px;
+}
+
+.terminal-title .terminal-command {
+  color: var(--accent);
+}
+
+.terminal-body {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
   gap: 16px;
 }
 
-.tip-card {
+.terminal-line {
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  background: var(--surface2);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 20px;
-  transition: all 0.2s;
+  padding: 12px 16px;
+  border-radius: 8px;
+  transition: background 0.2s;
 }
 
-.tip-card:hover {
-  border-color: var(--accent);
-  background: rgba(56,189,248,0.04);
+.terminal-line:hover {
+  background: rgba(56,189,248,0.05);
 }
 
-.tip-icon {
-  font-size: 20px;
-  flex-shrink: 0;
-  margin-top: 1px;
-}
-
-.tip-text {
+.terminal-num {
+  font-family: 'JetBrains Mono', monospace;
   font-size: 13px;
-  color: var(--muted2);
-  line-height: 1.65;
-  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  flex-shrink: 0;
+  min-width: 24px;
 }
 
-@media (max-width: 900px) {
-  .tips-grid { grid-template-columns: repeat(2, 1fr); }
+.terminal-icon {
+  font-size: 18px;
+  flex-shrink: 0;
 }
+
+.terminal-text {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  color: #a8b8c8;
+  line-height: 1.6;
+}
+
 @media (max-width: 600px) {
-  .tips-grid { grid-template-columns: 1fr; }
   .htu-tips-section { padding: 60px 0; }
+  .terminal-body { padding: 12px; }
+  .terminal-line { padding: 10px; gap: 8px; }
+  .terminal-text { font-size: 12px; }
 }
 
 /* FAQ */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3453,13 +3453,21 @@ body.light-mode .gh-preview {
 .faq-item {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-left: 3px solid transparent;
+  border-radius: 14px;
   overflow: hidden;
-  transition: border-color 0.2s;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.faq-item:hover {
+  border-color: var(--border2);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.08);
 }
 
 .faq-item.open {
   border-color: rgba(56,189,248,0.3);
+  border-left-color: var(--accent);
+  box-shadow: 0 6px 24px rgba(56, 189, 248, 0.1);
 }
 
 .faq-question {
@@ -3503,6 +3511,12 @@ body.light-mode .gh-preview {
   font-family: 'Space Grotesk', sans-serif;
   border-top: 1px solid var(--border);
   padding-top: 16px;
+  animation: faqIn 0.25s  cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes faqIn {
+  from { opacity: 0; transform: translateY(-8px); }
+  to {opacity: 1; transform: translateY(0); }
 }
 
 @media (max-width: 600px) {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3222,8 +3222,18 @@ body.light-mode .gh-preview {
   top: 60px;
   bottom: 0;
   width: 2px;
-  background: linear-gradient(to bottom, var(--accent), transparent);
-  opacity: 0.3;
+  background: linear-gradient(
+    to bottom,
+    var(--accent) 0%,
+    var(--accent2) 50%,
+    transparent 100%
+  );
+  opacity: 0.25;
+}
+
+@keyframes stepGlow {
+  0%, 100% { box-shadow: 0 4px 16px rgba(56,189,248,0.3); }
+  50%       { box-shadow: 0 4px 28px rgba(56,189,248,0.6), 0 0 0 6px rgba(56,189,248,0.08); }
 }
 
 .htu-step-num {
@@ -3239,19 +3249,59 @@ body.light-mode .gh-preview {
   font-size: 14px;
   font-weight: 700;
   color: #fff;
-  box-shadow: 0 4px 16px rgba(56,189,248,0.3);
   position: relative;
   z-index: 1;
+  animation: stepGlow 3s ease-in-out infinite;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.htu-step:hover .htu-step-num {
+  transform: scale(1.12);
+  animation: none;
+  box-shadow: 0 8px 32px rgba(56,189,248,0.6), 0 0 0 8px rgba(56,189,248,0.1);
 }
 
 .htu-step-content {
   flex: 1;
-  padding-top: 8px;
+  padding: 20px 24px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  border-left: 3px solid transparent;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.htu-step-content::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(56,189,248,0.03), rgba(129,140,248,0.03));
+  opacity: 0;
+  transition: opacity 0.25s;
+  pointer-events: none;
+}
+
+.htu-step:hover .htu-step-content {
+  border-color: rgba(56,189,248,0.3);
+  border-left-color: var(--accent);
+  transform: translateX(6px);
+  box-shadow: 0 8px 28px rgba(0,0,0,0.15);
+}
+
+.htu-step:hover .htu-step-content::before {
+  opacity: 1;
 }
 
 .htu-step-icon {
   font-size: 22px;
-  margin-bottom: 6px;
+  margin-bottom: 8px;
+  display: inline-block;
+  transition: transform 0.2 ease;
+}
+.htu-step:hover .htu-step-icon{
+  transform: scale(1.2) rotate(-5deg);
 }
 
 .htu-step-title {
@@ -3260,6 +3310,10 @@ body.light-mode .gh-preview {
   color: var(--text);
   margin-bottom: 8px;
   letter-spacing: -0.2px;
+  transition: color 0.2s;
+}
+.htu-step:hover  .htu-step-title{
+  color: var(--accent)
 }
 
 .htu-step-desc {
@@ -3271,9 +3325,11 @@ body.light-mode .gh-preview {
 }
 
 @media (max-width: 600px) {
-  .htu-step { gap: 16px; }
+  .htu-step { gap: 14px; padding-bottom: 24px; }
   .htu-step-num { width: 44px; height: 44px; font-size: 12px; }
   .htu-step:not(:last-child)::after { left: 21px; }
+  .htu-steps-content { padding: 14px 16px; }
+  .htu-step:hover  .htu-step-content { transform: translateX(3px); }
   .htu-steps-section { padding: 60px 0; }
 }
 


### PR DESCRIPTION
## What this PR does

Enhance the 'How To Use' page with an improved visual design and enhanced interactions.

Closes #138

## Changes
- Steps: card hover effect, glow animation on step numbers, 
  accent border and slide on hover
- Tips: redesigned as a terminal-style block with glowing 
  border and numbered lines
- FAQ: left accent border when open, smooth answer animation

## Files Changed
- `src/styles/index.css`
- `src/pages/HowToUse/HowToUsePage.jsx`

## Tested
- Dark and light themes 
- Mobile responsive 
- no console errors

**BEFORE-**
<img width="1366" height="768" alt="Screenshot (84)" src="https://github.com/user-attachments/assets/5cd2e07b-608f-435c-8b0f-22bec64d7646" />

**AFTER-**
<img width="1355" height="639" alt="Screenshot (85)" src="https://github.com/user-attachments/assets/34667305-5faf-449f-950c-e00a464a1576" />



**TIPS SECTION-**
<img width="1351" height="638" alt="Screenshot (86)" src="https://github.com/user-attachments/assets/1abdd982-5157-4fc3-87cc-d564dfbefb1f" />


## Additional Notes

 Terminal tips required JSX changes to restructure 
  the tips markup.
 All styles use existing CSS variables so dark and 
  light themes works.
 No new dependencies added.

