### PR TITLE
feat(mobile): optimize workspace layout via viewport isolation and en…

### DIFF
--- a/readmeforge.css
+++ b/readmeforge.css
@@ -617,6 +617,14 @@ body.light-mode .hero-title {
   height: calc(100vh - 64px);
 }
 
+.mobile-tab-switcher {
+  display: none;
+}
+
+.mobile-panel-wrapper {
+  min-width: 0;
+}
+
 .sidebar {
   width: 280px;
   flex-shrink: 0;
@@ -1821,10 +1829,60 @@ body.light-mode .gh-preview {
    RESPONSIVENESS (MOBILE & TABLET)
 ======================================================= */
 @media (max-width: 1024px) {
+  #app-builder {
+    height: calc(100dvh - 64px);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .mobile-tab-switcher {
+    display: flex;
+    gap: 8px;
+    padding: 12px 16px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+    flex-shrink: 0;
+  }
+
+  .mobile-tab-switcher-btn {
+    flex: 1 0 0;
+    min-width: 0;
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border2);
+    background: var(--surface2);
+    color: var(--muted2);
+    font-family: "Space Grotesk", sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+
+  .mobile-tab-switcher-btn.active {
+    color: #fff;
+    border-color: var(--accent);
+    background: linear-gradient(135deg, var(--accent), var(--accent2));
+    box-shadow: 0 8px 24px rgba(56, 189, 248, 0.18);
+  }
+
   .main {
     flex-direction: column;
     height: auto;
     min-height: calc(100vh - 64px);
+    flex: 1;
+    min-height: 0;
+  }
+
+  .mobile-panel-wrapper {
+    display: none;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .mobile-panel-wrapper.active {
+    display: block;
   }
 
   .sidebar {
@@ -1847,6 +1905,14 @@ body.light-mode .gh-preview {
   .editor,
   .preview {
     overflow: visible;
+  }
+
+  .mobile-panel-wrapper.active .sidebar,
+  .mobile-panel-wrapper.active .editor,
+  .mobile-panel-wrapper.active .preview {
+    width: 100%;
+    height: 100%;
+    overflow-y: auto;
   }
 }
 
@@ -2323,6 +2389,59 @@ body.light-mode .gh-preview {
   transform: translateY(-3px);
   box-shadow: 0 6px 16px rgba(56, 189, 248, 0.6);
   background: var(--accent2);
+}
+
+/* ── PREVIEW FOCUS MODE ── */
+.fullscreen-preview-overlay {
+  position: fixed !important;
+  inset: 0 !important;
+  z-index: 5000;
+  width: 100vw;
+  height: 100dvh;
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+}
+
+.preview-tabs .icon-btn {
+  flex: 0 0 36px;
+  width: 36px;
+  min-width: 36px;
+  height: 36px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.exit-focus-btn {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 5100;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border2);
+  background: rgba(10, 15, 26, 0.92);
+  color: var(--text);
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  backdrop-filter: blur(16px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.exit-focus-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+body.light-mode .exit-focus-btn {
+  background: rgba(255, 255, 255, 0.94);
 }
 
 /* ── PRINT MEDIA STYLES ── */

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -73,14 +73,6 @@ export default function Navbar() {
           </svg>
           Source
         </a>
-        <button
-          type="button"
-          className="theme-toggle mobile-only"
-          title="Toggle dark/light mode"
-          onClick={toggleTheme}
-        >
-          {theme === 'dark' ? '🌙' : '☀️'}
-        </button>
         {/* Source link moved to actions area so it stays beside theme toggle */}
       </div>
 
@@ -102,6 +94,15 @@ export default function Navbar() {
           type="button"
           className="theme-toggle desktop-only"
           id="themeToggle"
+          title="Toggle dark/light mode"
+          onClick={toggleTheme}
+        >
+          {theme === 'dark' ? '🌙' : '☀️'}
+        </button>
+
+        <button
+          type="button"
+          className="theme-toggle mobile-only-toggle"
           title="Toggle dark/light mode"
           onClick={toggleTheme}
         >

--- a/src/pages/ReadmeMaker/PreviewPanel.jsx
+++ b/src/pages/ReadmeMaker/PreviewPanel.jsx
@@ -52,6 +52,7 @@ function calculateQuality({ formData, sectionState, selectedTechs, screenshots }
 export default function PreviewPanel({ currentMd, formData, sectionState, selectedTechs, screenshots }) {
   const toast = useToast();
   const [tab, setTabState] = useState('rendered');
+  const [isFocusMode, setIsFocusMode] = useState(false);
   const [zoom, setZoom] = useState(() => {
     try {
       const raw = localStorage.getItem(PREVIEW_ZOOM_KEY);
@@ -87,6 +88,15 @@ export default function PreviewPanel({ currentMd, formData, sectionState, select
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [zoom]);
+
+  useEffect(() => {
+    if (isFocusMode) {
+      document.body.classList.add('mobile-focus-active');
+    } else {
+      document.body.classList.remove('mobile-focus-active');
+    }
+    return () => document.body.classList.remove('mobile-focus-active');
+  }, [isFocusMode]);
 
   function zoomIn() {
     const next = ZOOM_LEVELS.find(l => l > zoom);
@@ -135,49 +145,45 @@ export default function PreviewPanel({ currentMd, formData, sectionState, select
   const zoomPct = Math.round(zoom * 100) + '%';
 
   return (
-    <aside className="preview">
-      <div className="preview-header">
-        <div className="preview-tabs">
-          <button
-            className={`ptab${tab === 'rendered' ? ' active' : ''}`}
-            onClick={() => setTabState('rendered')}
-          >
-            Preview
-          </button>
-          <button
-            className={`ptab${tab === 'raw' ? ' active' : ''}`}
-            onClick={() => setTabState('raw')}
-          >
-            Raw MD
-          </button>
-        </div>
-        <div className="preview-actions">
-          <div className="preview-zoom-controls">
-            <button className="pbtn" onClick={zoomOut} disabled={zoom <= ZOOM_LEVELS[0]} title="Zoom out (Ctrl -)">−</button>
-            <span className="zoom-indicator">{zoomPct}</span>
-            <button className="pbtn" onClick={zoomIn} disabled={zoom >= ZOOM_LEVELS[ZOOM_LEVELS.length - 1]} title="Zoom in (Ctrl +)">+</button>
-            <button className="pbtn" onClick={() => setZoom(1)} title="Reset zoom (Ctrl 0)">Reset</button>
+    <aside className={`preview${isFocusMode ? ' fullscreen-preview-overlay' : ''}`}>
+      {!isFocusMode ? (
+        <div className="preview-header">
+          <div className="preview-tabs">
+            <button
+              className={`ptab${tab === 'rendered' ? ' active' : ''}`}
+              onClick={() => setTabState('rendered')}
+            >
+              Preview
+            </button>
+            <button
+              className={`ptab${tab === 'raw' ? ' active' : ''}`}
+              onClick={() => setTabState('raw')}
+            >
+              Raw MD
+            </button>
           </div>
-          <button className="pbtn green" onClick={copyMarkdown}>
-            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-            </svg>
-            Copy Markdown
-          </button>
-          <button className="pbtn" onClick={downloadMd}>
-            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" /><polyline points="7,10 12,15 17,10" /><line x1="12" y1="15" x2="12" y2="3" />
-            </svg>
-            Download .md
-          </button>
-          <button className="pbtn print" onClick={printPreview}>
-            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <polyline points="6 9 6 2 18 2 18 9" /><path d="M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2" /><rect x="6" y="14" width="12" height="8" />
-            </svg>
-            Print Preview
-          </button>
+          <div className="preview-actions">
+            <button className="pbtn green" onClick={copyMarkdown}>
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+              </svg>
+              Copy Markdown
+            </button>
+            <button className="pbtn" onClick={downloadMd}>
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" /><polyline points="7,10 12,15 17,10" /><line x1="12" y1="15" x2="12" y2="3" />
+              </svg>
+              Download .md
+            </button>
+            <button className="pbtn print" onClick={printPreview}>
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <polyline points="6 9 6 2 18 2 18 9" /><path d="M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2" /><rect x="6" y="14" width="12" height="8" />
+              </svg>
+              Print Preview
+            </button>
+          </div>
         </div>
-      </div>
+      ) : null}
 
       {hasContent && (
         <div className="quality-panel" id="qualityPanel">
@@ -247,6 +253,22 @@ export default function PreviewPanel({ currentMd, formData, sectionState, select
       )}
 
       <div className="preview-body" ref={previewBodyRef} style={{ '--preview-zoom': zoom }}>
+        <div className="preview-zoom-controls">
+          <button className="pbtn" onClick={zoomOut} disabled={zoom <= ZOOM_LEVELS[0]} title="Zoom out (Ctrl -)">−</button>
+          <span className="zoom-indicator">{zoomPct}</span>
+          <button className="pbtn" onClick={zoomIn} disabled={zoom >= ZOOM_LEVELS[ZOOM_LEVELS.length - 1]} title="Zoom in (Ctrl +)">+</button>
+          <button className="pbtn" onClick={() => setZoom(1)} title="Reset zoom (Ctrl 0)">Reset</button>
+
+          {!isFocusMode && (
+            <button onClick={() => setIsFocusMode(true)} className="floating-focus-btn" aria-label="Focus View">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                <circle cx="12" cy="12" r="3"></circle>
+              </svg>
+            </button>
+          )}
+        </div>
+
         {!hasContent ? (
           <div className="preview-zoom-wrap">
             <div className="empty-preview">
@@ -265,6 +287,16 @@ export default function PreviewPanel({ currentMd, formData, sectionState, select
           </div>
         )}
       </div>
+
+      {isFocusMode ? (
+        <button onClick={() => setIsFocusMode(false)} className="exit-focus-btn" aria-label="Exit Focus Mode">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+          Exit Focus
+        </button>
+      ) : null}
 
       {showBackTop && (
         <button

--- a/src/pages/ReadmeMaker/ReadmeMaker.jsx
+++ b/src/pages/ReadmeMaker/ReadmeMaker.jsx
@@ -175,41 +175,6 @@ export default function ReadmeMaker() {
           </div>
         </div>
 
-        <div className="main" style={{ height: 'calc(100vh - 128px)' }}>
-          <div className={`mobile-panel-wrapper${activeMobileTab === 'setup' ? ' active' : ''}`}>
-            <Sidebar
-              sectionState={sectionState}
-              toggleSection={toggleSection}
-              selectedTechs={selectedTechs}
-              toggleTech={toggleTech}
-              applyTemplate={handleApplyTemplate}
-              activeTemplate={activeTemplate}
-            />
-          </div>
-          <div className={`mobile-panel-wrapper${activeMobileTab === 'editor' ? ' active' : ''}`}>
-            <EditorPanel
-              formData={formData}
-              updateField={updateField}
-              sectionState={sectionState}
-              selectedTechs={selectedTechs}
-              toggleTech={toggleTech}
-              selectedBadges={selectedBadges}
-              toggleBadge={toggleBadge}
-              screenshots={screenshots}
-              addScreenshots={addScreenshots}
-              removeScreenshot={removeScreenshot}
-            />
-          </div>
-          <div className={`mobile-panel-wrapper${activeMobileTab === 'preview' ? ' active' : ''}`}>
-            <PreviewPanel
-              currentMd={currentMd}
-              formData={formData}
-              sectionState={sectionState}
-              selectedTechs={selectedTechs}
-              screenshots={screenshots}
-            />
-          </div>
-        </div>
 
         {/* Mobile Global Scroll-to-Top */}
         <button

--- a/src/pages/ReadmeMaker/ReadmeMaker.jsx
+++ b/src/pages/ReadmeMaker/ReadmeMaker.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useMemo } from 'react';
+import { useEffect, useRef, useMemo, useState } from 'react';
 import { useReadmeState } from '../../hooks/useReadmeState';
 import { useToast } from '../../components/ui/Toast';
 import { generateMarkdown } from '../../utils/markdownUtils';
@@ -8,7 +8,6 @@ import EditorPanel from './EditorPanel';
 import PreviewPanel from './PreviewPanel';
 import Navbar from '../../components/layout/Navbar';
 import SEOHead from '../../components/shared/SEOHead';
-import { useState } from 'react';
 
 export default function ReadmeMaker() {
   const toast = useToast();
@@ -25,6 +24,7 @@ export default function ReadmeMaker() {
   } = useReadmeState();
 
   const [activeTemplate, setActiveTemplate] = useState(null);
+  const [activeMobileTab, setActiveMobileTab] = useState('editor');
 
   const currentMd = useMemo(() =>
     generateMarkdown({ formData, sectionState, selectedTechs, selectedBadges, screenshots, sectionOrder }),
@@ -56,6 +56,21 @@ export default function ReadmeMaker() {
     clearSaved();
     toast('✓ Saved data cleared!');
   }
+
+  useEffect(() => {
+    // Industry-standard fix for iOS Safari keyboard void glitch
+    const handleKeyboardDismiss = (e) => {
+      if (['INPUT', 'TEXTAREA', 'SELECT'].includes(e.target.tagName)) {
+        // Wait a tiny fraction of a second for the keyboard to fully retract, then snap the viewport back
+        setTimeout(() => {
+          window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+        }, 50);
+      }
+    };
+    
+    document.addEventListener('focusout', handleKeyboardDismiss);
+    return () => document.removeEventListener('focusout', handleKeyboardDismiss);
+  }, []);
 
   return (
     <>
@@ -98,37 +113,120 @@ export default function ReadmeMaker() {
           </div>
         </header>
 
-        <div className="main" style={{ height: 'calc(100vh - 128px)' }}>
-          <Sidebar
-            sectionState={sectionState}
-            toggleSection={toggleSection}
-            sectionOrder={sectionOrder}
-            updateSectionOrder={updateSectionOrder}
-            selectedTechs={selectedTechs}
-            toggleTech={toggleTech}
-            applyTemplate={handleApplyTemplate}
-            activeTemplate={activeTemplate}
-          />
-          <EditorPanel
-            formData={formData}
-            updateField={updateField}
-            sectionState={sectionState}
-            selectedTechs={selectedTechs}
-            toggleTech={toggleTech}
-            selectedBadges={selectedBadges}
-            toggleBadge={toggleBadge}
-            screenshots={screenshots}
-            addScreenshots={addScreenshots}
-            removeScreenshot={removeScreenshot}
-          />
-          <PreviewPanel
-            currentMd={currentMd}
-            formData={formData}
-            sectionState={sectionState}
-            selectedTechs={selectedTechs}
-            screenshots={screenshots}
-          />
+<div className="mobile-tab-switcher">
+          <button
+            type="button"
+            className={`mobile-tab-switcher-btn${activeMobileTab === 'setup' ? ' active' : ''}`}
+            onClick={() => setActiveMobileTab('setup')}
+          >
+            Setup
+          </button>
+          <button
+            type="button"
+            className={`mobile-tab-switcher-btn${activeMobileTab === 'editor' ? ' active' : ''}`}
+            onClick={() => setActiveMobileTab('editor')}
+          >
+            Editor
+          </button>
+          <button
+            type="button"
+            className={`mobile-tab-switcher-btn${activeMobileTab === 'preview' ? ' active' : ''}`}
+            onClick={() => setActiveMobileTab('preview')}
+          >
+            Preview
+          </button>
         </div>
+
+        <div className="main" style={{ height: 'calc(100vh - 128px)' }}>
+          <div className={`mobile-panel-wrapper${activeMobileTab === 'setup' ? ' active' : ''}`}>
+            <Sidebar
+              sectionState={sectionState}
+              toggleSection={toggleSection}
+              sectionOrder={sectionOrder}
+              updateSectionOrder={updateSectionOrder}
+              selectedTechs={selectedTechs}
+              toggleTech={toggleTech}
+              applyTemplate={handleApplyTemplate}
+              activeTemplate={activeTemplate}
+            />
+          </div>
+          <div className={`mobile-panel-wrapper${activeMobileTab === 'editor' ? ' active' : ''}`}>
+            <EditorPanel
+              formData={formData}
+              updateField={updateField}
+              sectionState={sectionState}
+              selectedTechs={selectedTechs}
+              toggleTech={toggleTech}
+              selectedBadges={selectedBadges}
+              toggleBadge={toggleBadge}
+              screenshots={screenshots}
+              addScreenshots={addScreenshots}
+              removeScreenshot={removeScreenshot}
+            />
+          </div>
+          <div className={`mobile-panel-wrapper${activeMobileTab === 'preview' ? ' active' : ''}`}>
+            <PreviewPanel
+              currentMd={currentMd}
+              formData={formData}
+              sectionState={sectionState}
+              selectedTechs={selectedTechs}
+              screenshots={screenshots}
+            />
+          </div>
+        </div>
+
+        <div className="main" style={{ height: 'calc(100vh - 128px)' }}>
+          <div className={`mobile-panel-wrapper${activeMobileTab === 'setup' ? ' active' : ''}`}>
+            <Sidebar
+              sectionState={sectionState}
+              toggleSection={toggleSection}
+              selectedTechs={selectedTechs}
+              toggleTech={toggleTech}
+              applyTemplate={handleApplyTemplate}
+              activeTemplate={activeTemplate}
+            />
+          </div>
+          <div className={`mobile-panel-wrapper${activeMobileTab === 'editor' ? ' active' : ''}`}>
+            <EditorPanel
+              formData={formData}
+              updateField={updateField}
+              sectionState={sectionState}
+              selectedTechs={selectedTechs}
+              toggleTech={toggleTech}
+              selectedBadges={selectedBadges}
+              toggleBadge={toggleBadge}
+              screenshots={screenshots}
+              addScreenshots={addScreenshots}
+              removeScreenshot={removeScreenshot}
+            />
+          </div>
+          <div className={`mobile-panel-wrapper${activeMobileTab === 'preview' ? ' active' : ''}`}>
+            <PreviewPanel
+              currentMd={currentMd}
+              formData={formData}
+              sectionState={sectionState}
+              selectedTechs={selectedTechs}
+              screenshots={screenshots}
+            />
+          </div>
+        </div>
+
+        {/* Mobile Global Scroll-to-Top */}
+        <button
+          className="mobile-global-top-btn"
+          onClick={() => {
+            const activeWrapper = document.querySelector('.mobile-panel-wrapper.active');
+            if (activeWrapper) activeWrapper.scrollTo({ top: 0, behavior: 'smooth' });
+            const innerTarget = activeWrapper?.firstElementChild;
+            if (innerTarget) innerTarget.scrollTo({ top: 0, behavior: 'smooth' });
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          }}
+          aria-label="Scroll to top"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="18 15 12 9 6 15" />
+          </svg>
+        </button>
       </div>
     </>
   );

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1949,7 +1949,6 @@ body.light-mode .gh-preview {
 @media (max-width: 1024px) {
   .main {
     flex-direction: column;
-    height: auto;
     min-height: calc(100vh - 64px);
   }
 
@@ -1979,9 +1978,9 @@ body.light-mode .gh-preview {
 @media (max-width: 768px) {
   .header {
     height: auto;
-    padding: 16px;
+    padding: 10px 16px !important;
     flex-direction: column;
-    gap: 16px;
+    gap: 8px !important;
     align-items: center;
   }
 
@@ -2005,6 +2004,10 @@ body.light-mode .gh-preview {
     min-width: 100px;
   }
 
+  .header-right .hbtn {
+    padding: 6px 12px !important;
+  }
+
   .two-col {
     grid-template-columns: 1fr;
     gap: 16px;
@@ -2019,35 +2022,152 @@ body.light-mode .gh-preview {
   }
 
   .preview-header {
-    flex-direction: column;
-    gap: 12px;
-    align-items: stretch;
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 10px !important;
+    align-items: stretch !important;
+    padding: 8px 16px !important;
   }
 
   .preview-tabs {
-    flex-wrap: wrap;
-    justify-content: center;
     width: 100%;
+    height: auto !important;
+    background: var(--surface3) !important;
+    padding: 3px !important;
+    border-radius: 10px !important;
+    display: flex;
+    align-items: center;
   }
 
   .preview-tabs .ptab {
-    flex: 1 1 140px;
+    flex: 1 !important;
+    padding: 8px 12px !important;
+    font-size: 12px !important;
+    border-radius: 8px !important;
+    text-align: center;
   }
 
   .preview-actions {
     width: 100%;
-    justify-content: space-between;
+    height: auto !important;
+    justify-content: flex-start;
     flex-wrap: wrap;
+    gap: 8px !important;
+    align-items: center;
   }
 
   .preview-actions .pbtn {
-    flex: 1;
+    flex: 1 !important;
+    width: auto !important;
+    min-width: 0 !important;
+    padding: 8px 14px !important;
     justify-content: center;
+  }
+
+  /* Force compact button height — overrides any global min-height bloat */
+  .preview-tabs .ptab,
+  .preview-actions .pbtn {
+    height: 32px !important;
+    min-height: 32px !important;
+    padding: 0 12px !important;
+    font-size: 12px !important;
+    line-height: 32px !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+  }
+
+  /* Kill the inherited flex-basis that is acting as a massive height */
+  .preview-tabs,
+  .preview-actions {
+    flex: 0 0 auto !important;
+    width: 100% !important;
+    height: auto !important;
+    padding: 6px !important;
+    border-radius: 12px !important;
+  }
+
+  /* Ensure buttons inside aren't creating hidden gaps */
+  .preview-actions .pbtn,
+  .preview-tabs .ptab {
+    margin: 0 !important;
   }
 
   .preview-zoom-controls {
     width: 100%;
     justify-content: center;
+    position: relative !important;
+    padding: 12px 16px !important;
+    gap: 16px !important;
+    padding-bottom: 16px;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .preview-zoom-controls .floating-focus-btn {
+    position: absolute !important;
+    top: 50% !important;
+    right: 16px !important;
+    transform: translateY(-50%) !important;
+  }
+
+  .preview-zoom-controls .pbtn {
+    width: 44px !important;
+    height: 44px !important;
+    padding: 0 !important;
+    border-radius: 50% !important;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto !important;
+  }
+
+  .preview-zoom-controls .zoom-indicator {
+    height: 44px !important;
+    padding: 0 20px !important;
+    display: flex;
+    align-items: center;
+  }
+
+  .preview-body {
+    padding: 16px 0 !important;
+  }
+
+  .gh-preview {
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    padding: 16px !important;
+  }
+
+  /* 1. Prevent mobile browser viewport shift by forcing accessible text sizing on inputs */
+  input[type="text"],
+  input[type="email"],
+  input[type="url"],
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+
+  /* 2. Hide surrounding cards, navbars, and score blocks during mobile focus view */
+  body.mobile-focus-active .site-nav,
+  body.mobile-focus-active .header,
+  body.mobile-focus-active .mobile-tab-switcher,
+  body.mobile-focus-active #qualityPanel {
+    display: none !important;
+  }
+
+  /* 3. Reclaim full viewport dimension for the main container */
+  body.mobile-focus-active .main {
+    height: 100dvh !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  /* Mobile Pinch-to-Zoom override inside Focus Mode */
+  .fullscreen-preview-overlay,
+  .fullscreen-preview-overlay .preview-body {
+    touch-action: pan-x pan-y pinch-zoom !important;
   }
 }
 
@@ -2607,6 +2727,35 @@ body.light-mode .gh-preview {
   transform: translateY(-3px);
   box-shadow: 0 6px 16px rgba(56, 189, 248, 0.6);
   background: var(--accent2);
+}
+
+.preview-body {
+  position: relative;
+}
+
+.floating-focus-btn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--header-bg);
+  border: 1px solid var(--border2);
+  color: var(--text);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: all 0.2s ease;
+}
+
+.floating-focus-btn:active {
+  transform: scale(0.92);
 }
 
 /* ── PRINT MEDIA STYLES ── */
@@ -3556,3 +3705,233 @@ body.light-mode .gh-preview {
   .faq-question { font-size: 14px; padding: 16px; }
   .faq-answer { padding: 0 16px 16px; padding-top: 12px; }
 }
+
+.mobile-global-top-btn {
+  display: none; /* Hidden by default on desktop */
+}
+
+/* =======================================================
+   README MAKER MOBILE TAB SWITCHER OVERRIDES
+   ======================================================= */
+.mobile-tab-switcher {
+  display: none;
+}
+
+.mobile-panel-wrapper {
+  display: contents;
+}
+
+@media (max-width: 1024px) {
+  .mobile-tab-switcher {
+    display: flex;
+    gap: 8px;
+    padding: 16px 16px !important;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .mobile-tab-switcher button {
+    flex: 1;
+    padding: 12px;
+    font-size: 14px;
+    border: 1px solid var(--border2);
+    border-radius: 8px;
+    background: var(--surface2);
+    color: var(--muted);
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 600;
+  }
+
+  .mobile-tab-switcher button.active {
+    background: rgba(56, 189, 248, 0.1);
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .main {
+    display: flex;
+    flex-direction: column;
+    height: calc(100dvh - 130px) !important;
+    overflow: hidden !important;
+  }
+
+  .mobile-panel-wrapper {
+    display: none;
+  }
+
+  .mobile-panel-wrapper.active {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    overflow-y: auto;
+  }
+
+  .mobile-panel-wrapper > * {
+    width: 100% !important;
+    min-height: 100% !important;
+    height: max-content !important;
+    border: none !important;
+    padding-bottom: 120px !important;
+  }
+
+  .mobile-panel-wrapper > .sidebar,
+  .mobile-panel-wrapper > .preview {
+    background-color: var(--surface) !important;
+  }
+
+  .mobile-global-top-btn {
+    display: flex !important;
+    position: fixed !important;
+    bottom: 24px !important;
+    right: 24px !important;
+    left: auto !important;
+    transform: none !important;
+    width: 44px !important;
+    height: 44px !important;
+    background: var(--surface2) !important;
+    color: var(--text) !important;
+    border: 1px solid var(--border2) !important;
+    padding: 0 !important;
+    border-radius: 50% !important;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4) !important;
+    z-index: 99990 !important;
+    align-items: center !important;
+    justify-content: center !important;
+    cursor: pointer !important;
+    backdrop-filter: blur(12px) !important;
+    transition: all 0.2s ease !important;
+  }
+
+  .mobile-global-top-btn:active {
+    background: var(--surface3) !important;
+    transform: scale(0.92) !important;
+  }
+
+  /* Keep the focus mode completely clean */
+  body.mobile-focus-active .mobile-global-top-btn {
+    display: none !important;
+  }
+}
+
+  /* ── FULLSCREEN FOCUS MODE ── */
+  .fullscreen-preview-overlay {
+    position: fixed !important;
+    inset: 0 !important;
+    z-index: 99999 !important;
+    background: var(--bg) !important;
+    display: flex !important;
+    flex-direction: column !important;
+    height: 100dvh !important;
+    width: 100vw !important;
+  }
+
+  .fullscreen-preview-overlay .preview-body {
+    padding: 24px 16px 100px !important; /* Extra bottom padding for the floating button */
+    height: 100% !important;
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* ── FLOATING EXIT BUTTON ── */
+  .exit-focus-btn {
+    position: fixed;
+    bottom: 32px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--surface2);
+    color: var(--text);
+    border: 1px solid var(--border2);
+    padding: 14px 28px;
+    border-radius: 50px;
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700;
+    font-size: 14px;
+    cursor: pointer;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+    z-index: 100000;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .exit-focus-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    transform: translateX(-50%) translateY(-4px);
+  }
+
+  /* ── COMPACT ICON BUTTON FIX ── */
+  .pbtn.icon-btn {
+    padding: 8px;
+    width: 36px;
+    height: 36px;
+    justify-content: center;
+    flex: 0 0 auto !important;
+    min-width: unset !important;
+  }
+
+/* ── DESKTOP-ONLY PREVIEW PANEL ALIGNMENT ── */
+@media (min-width: 1025px) {
+  .preview-body .preview-zoom-controls {
+    display: flex !important;
+    justify-content: center !important;
+    align-items: center !important;
+    gap: 12px !important;
+    background: var(--surface2) !important;
+    border-bottom: 1px solid var(--border) !important;
+    padding: 10px 24px !important;
+    margin: -24px -24px 24px -24px !important;
+    width: calc(100% + 48px) !important;
+  }
+
+  .preview-body .preview-zoom-controls .pbtn {
+    width: 32px !important;
+    height: 32px !important;
+    border-radius: 6px !important;
+  }
+
+  .preview-body .preview-zoom-controls .pbtn[title*="Reset"] {
+    width: auto !important;
+    padding: 0 12px !important;
+  }
+
+  .preview-body .preview-zoom-controls .floating-focus-btn {
+    position: static !important;
+    transform: none !important;
+    width: 32px !important;
+    height: 32px !important;
+    border-radius: 6px !important;
+    background: var(--surface3) !important;
+    border: 1px solid var(--border2) !important;
+    margin-left: 8px !important;
+  }
+}
+
+/* ── MOBILE TOP BAR THEME TOGGLE ── */
+.mobile-only-toggle {
+  display: none; /* Hidden on desktop viewports */
+}
+
+@media (max-width: 768px) {
+  .mobile-only-toggle {
+    display: inline-flex !important;
+    padding: 8px !important;
+    border-radius: 8px !important;
+    font-size: 16px !important;
+    border: 1px solid var(--border2) !important;
+    background: var(--surface2) !important;
+    color: var(--text) !important;
+    cursor: pointer !important;
+    width: 36px !important;
+    height: 36px !important;
+    align-items: center !important;
+    justify-content: center !important;
+    margin-right: 4px !important; /* Elegant padding space right before the hamburger */
+  }
+  
+  .mobile-only-toggle:active {
+    transform: scale(0.92);
+  }
+}
+


### PR DESCRIPTION

**Related Issue**
Fixes #121 

## Description
This PR fixes the mobile layout usability issues on the workspace screen. On desktop, the three-column setup works great, but on mobile, the panels stacked into an endless vertical page.

I implemented a viewport isolation strategy using a mobile-only tab switcher (Setup, Editor, Preview). This keeps the layout locked to a single panel at a time, entirely eliminating the endless scroll trap on phones while leaving the desktop design 100% untouched.

## Key Changes
**1. Mobile Tab Switcher & Layout Separation**

Added a smartphone-native tab bar below the header to toggle between Setup, Editor, and Preview screens on mobile viewports.

**2. Full-Screen Focus Mode Upgrades**

I have added new focus mode in both desktop and mobile version to view the Readme file preview more clearly.

**3. Mobile Accessibility & Polish**

Relocated Theme Toggle: Moved the mobile theme switch out of the hamburger menu dropdown directly onto the top navigation bar for one-tap convenience.

Global Scroll-to-Top: Added a mobile-only floating pill button that smoothly returns the user back to the tab navigation bar when working inside long forms.

**4. Layout & Bug Fixes**

Keyboard Void Fix: Added a focusout event pipeline tracking when focus leaves input fields. It forcefully resets the visual viewport to window.scrollTo(0, 0) once the keyboard drops, clearing the stubborn blank bottom void.

Auto-Zoom Prevention: Increased input, textarea, and select mobile font sizes to 16px to prevent from forcing an unwanted page layout scale-in on focus.


## Before

https://github.com/user-attachments/assets/928b61ec-3837-4678-8cd1-046480d83c34

## After

https://github.com/user-attachments/assets/dd1c403f-4b81-46dd-8342-f2a5855381a9

## Testing Checklist
[x] Verified desktop three-column layout remains pixel-perfect.

[x] Confirmed mobile inputs do not trigger layout scale jumps on focus.

[x] Tested keyboard appearance/dismissal on a real mobile browser to verify the bottom blank void is resolved.

[x] Verified full-screen focus mode and back-to-top buttons toggle visibility smoothly on physical mobile touchscreens.


