### PR TITLE
feat: add drag-and-drop README section reordering

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,6 +1,6 @@
 import { STORAGE_KEY, PREVIEW_ZOOM_KEY, FIELD_IDS, ZOOM_LEVELS } from '../utils/constants';
 
-export function saveData({ formData, sectionState, selectedTechs, selectedBadges }) {
+export function saveData({ formData, sectionState, selectedTechs, selectedBadges, sectionOrder }) {
   try {
     const data = {
       fields: { ...formData },
@@ -8,6 +8,7 @@ export function saveData({ formData, sectionState, selectedTechs, selectedBadges
       techs: Array.from(selectedTechs),
       badges: Array.from(selectedBadges),
       sections: { ...sectionState },
+      sectionOrder: sectionOrder || [],
     };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
     return true;

--- a/src/hooks/useReadmeState.js
+++ b/src/hooks/useReadmeState.js
@@ -37,6 +37,15 @@ export function useReadmeState() {
     return defaults;
   });
 
+  const [sectionOrder, setSectionOrder] = useState(() => {
+    if (saved?.sectionOrder) {
+      const savedOrder = saved.sectionOrder.filter(id => SECTIONS.some(sec => sec.id === id));
+      const missing = SECTIONS.map(sec => sec.id).filter(id => !savedOrder.includes(id));
+      return [...savedOrder, ...missing];
+    }
+    return SECTIONS.map(sec => sec.id);
+  });
+
   const [selectedTechs, setSelectedTechs] = useState(() =>
     saved?.techs ? new Set(saved.techs) : new Set()
   );
@@ -50,10 +59,10 @@ export function useReadmeState() {
   const saveTimerRef = useRef(null);
   const autoSaveTimerRef = useRef(null);
 
-  const scheduleSave = useCallback((fd, ss, st, sb) => {
+  const scheduleSave = useCallback((fd, ss, st, sb, so) => {
     clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
-      saveData({ formData: fd, sectionState: ss, selectedTechs: st, selectedBadges: sb });
+      saveData({ formData: fd, sectionState: ss, selectedTechs: st, selectedBadges: sb, sectionOrder: so });
       setAutoSaved(true);
       clearTimeout(autoSaveTimerRef.current);
       autoSaveTimerRef.current = setTimeout(() => setAutoSaved(false), 2000);
@@ -63,36 +72,41 @@ export function useReadmeState() {
   const updateField = useCallback((field, value) => {
     setFormData(prev => {
       const next = { ...prev, [field]: value };
-      scheduleSave(next, sectionState, selectedTechs, selectedBadges);
+      scheduleSave(next, sectionState, selectedTechs, selectedBadges, sectionOrder);
       return next;
     });
-  }, [sectionState, selectedTechs, selectedBadges, scheduleSave]);
+  }, [sectionState, selectedTechs, selectedBadges, sectionOrder, scheduleSave]);
 
   const toggleSection = useCallback((id, checked) => {
     setSectionState(prev => {
       const next = { ...prev, [id]: checked };
-      scheduleSave(formData, next, selectedTechs, selectedBadges);
+      scheduleSave(formData, next, selectedTechs, selectedBadges, sectionOrder);
       return next;
     });
-  }, [formData, selectedTechs, selectedBadges, scheduleSave]);
+  }, [formData, selectedTechs, selectedBadges, sectionOrder, scheduleSave]);
+
+  const updateSectionOrder = useCallback((newOrder) => {
+    setSectionOrder(newOrder);
+    scheduleSave(formData, sectionState, selectedTechs, selectedBadges, newOrder);
+  }, [formData, sectionState, selectedTechs, selectedBadges, scheduleSave]);
 
   const toggleTech = useCallback((label) => {
     setSelectedTechs(prev => {
       const next = new Set(prev);
       if (next.has(label)) next.delete(label); else next.add(label);
-      scheduleSave(formData, sectionState, next, selectedBadges);
+      scheduleSave(formData, sectionState, next, selectedBadges, sectionOrder);
       return next;
     });
-  }, [formData, sectionState, selectedBadges, scheduleSave]);
+  }, [formData, sectionState, selectedBadges, sectionOrder, scheduleSave]);
 
   const toggleBadge = useCallback((id) => {
     setSelectedBadges(prev => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id); else next.add(id);
-      scheduleSave(formData, sectionState, selectedTechs, next);
+      scheduleSave(formData, sectionState, selectedTechs, next, sectionOrder);
       return next;
     });
-  }, [formData, sectionState, selectedTechs, scheduleSave]);
+  }, [formData, sectionState, selectedTechs, sectionOrder, scheduleSave]);
 
   const applyTemplate = useCallback((template) => {
     setFormData(prev => {
@@ -109,16 +123,17 @@ export function useReadmeState() {
         bibtexCitation: template.bibtexCitation || '',
       };
       const nextSections = { ...sectionState, academic: !!template.abstractText };
-      scheduleSave(next, nextSections, new Set(template.techs), selectedBadges);
+      scheduleSave(next, nextSections, new Set(template.techs), selectedBadges, sectionOrder);
       return next;
     });
     setSectionState(prev => ({ ...prev, academic: !!template.abstractText }));
     setSelectedTechs(new Set(template.techs));
-  }, [sectionState, selectedBadges, scheduleSave]);
+  }, [sectionState, selectedBadges, sectionOrder, scheduleSave]);
 
   const resetAll = useCallback(() => {
     setFormData(initialFormData);
     setSectionState(buildDefaultSectionState());
+    setSectionOrder(SECTIONS.map(sec => sec.id));
     setSelectedTechs(new Set());
     setSelectedBadges(new Set(DEFAULT_BADGES));
     setScreenshots([]);
@@ -147,6 +162,7 @@ export function useReadmeState() {
   return {
     formData, updateField,
     sectionState, toggleSection,
+    sectionOrder, updateSectionOrder,
     selectedTechs, toggleTech,
     selectedBadges, toggleBadge,
     screenshots, addScreenshots, removeScreenshot,

--- a/src/pages/ReadmeMaker/ReadmeMaker.jsx
+++ b/src/pages/ReadmeMaker/ReadmeMaker.jsx
@@ -16,6 +16,7 @@ export default function ReadmeMaker() {
   const {
     formData, updateField,
     sectionState, toggleSection,
+    sectionOrder, updateSectionOrder,
     selectedTechs, toggleTech,
     selectedBadges, toggleBadge,
     screenshots, addScreenshots, removeScreenshot,
@@ -26,8 +27,8 @@ export default function ReadmeMaker() {
   const [activeTemplate, setActiveTemplate] = useState(null);
 
   const currentMd = useMemo(() =>
-    generateMarkdown({ formData, sectionState, selectedTechs, selectedBadges, screenshots }),
-    [formData, sectionState, selectedTechs, selectedBadges, screenshots]
+    generateMarkdown({ formData, sectionState, selectedTechs, selectedBadges, screenshots, sectionOrder }),
+    [formData, sectionState, selectedTechs, selectedBadges, screenshots, sectionOrder]
   );
 
   const activeSectionCount = Object.values(sectionState).filter(Boolean).length;
@@ -89,6 +90,8 @@ export default function ReadmeMaker() {
           <Sidebar
             sectionState={sectionState}
             toggleSection={toggleSection}
+            sectionOrder={sectionOrder}
+            updateSectionOrder={updateSectionOrder}
             selectedTechs={selectedTechs}
             toggleTech={toggleTech}
             applyTemplate={handleApplyTemplate}

--- a/src/pages/ReadmeMaker/Sidebar.jsx
+++ b/src/pages/ReadmeMaker/Sidebar.jsx
@@ -1,10 +1,35 @@
+import { useState } from 'react';
 import { SECTIONS, TECHS, TEMPLATES } from '../../utils/constants';
 
 export default function Sidebar({
   sectionState, toggleSection,
+  sectionOrder, updateSectionOrder,
   selectedTechs, toggleTech,
   applyTemplate, activeTemplate,
 }) {
+  const [draggedIndex, setDraggedIndex] = useState(null);
+
+  const handleDragStart = (e, index) => {
+    setDraggedIndex(index);
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', String(index));
+  };
+
+  const handleDragEnter = (e, targetIndex) => {
+    if (draggedIndex === null || draggedIndex === targetIndex) return;
+
+    const newOrder = [...sectionOrder];
+    const [draggedItem] = newOrder.splice(draggedIndex, 1);
+    newOrder.splice(targetIndex, 0, draggedItem);
+
+    setDraggedIndex(targetIndex);
+    updateSectionOrder(newOrder);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedIndex(null);
+  };
+
   const activeSectionCount = Object.values(sectionState).filter(Boolean).length;
 
   return (
@@ -33,27 +58,43 @@ export default function Sidebar({
       </div>
 
       <div className="sidebar-section" style={{ flex: 1 }}>
-        <div className="sidebar-label">Sections</div>
+        <div className="sidebar-label">Sections <span style={{ fontSize: 10, fontWeight: 500, color: 'var(--muted)', marginLeft: 6 }}>(drag to reorder)</span></div>
         <div className="section-toggles">
-          {SECTIONS.map(sec => (
-            <div
-              key={sec.id}
-              className={`sec-toggle${sectionState[sec.id] ? ' active' : ''}`}
-            >
-              <div className="sec-toggle-left">
-                <span className="sec-toggle-icon">{sec.icon}</span>
-                {sec.label}
+          {sectionOrder.map((id, idx) => {
+            const sec = SECTIONS.find(s => s.id === id);
+            if (!sec) return null;
+            return (
+              <div
+                key={sec.id}
+                className={`sec-toggle${sectionState[sec.id] ? ' active' : ''}${draggedIndex === idx ? ' dragging' : ''}`}
+                draggable
+                onDragStart={(e) => handleDragStart(e, idx)}
+                onDragEnter={(e) => handleDragEnter(e, idx)}
+                onDragEnd={handleDragEnd}
+                onDragOver={(e) => e.preventDefault()}
+              >
+                <div className="sec-toggle-left">
+                  <div className="drag-handle" title="Drag to reorder">
+                    <svg width="10" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                      <circle cx="9" cy="5" r="1.5" /><circle cx="15" cy="5" r="1.5" />
+                      <circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" />
+                      <circle cx="9" cy="19" r="1.5" /><circle cx="15" cy="19" r="1.5" />
+                    </svg>
+                  </div>
+                  <span className="sec-toggle-icon">{sec.icon}</span>
+                  {sec.label}
+                </div>
+                <label className="toggle-switch">
+                  <input
+                    type="checkbox"
+                    checked={sectionState[sec.id]}
+                    onChange={e => toggleSection(sec.id, e.target.checked)}
+                  />
+                  <span className="tslider" />
+                </label>
               </div>
-              <label className="toggle-switch">
-                <input
-                  type="checkbox"
-                  checked={sectionState[sec.id]}
-                  onChange={e => toggleSection(sec.id, e.target.checked)}
-                />
-                <span className="tslider" />
-              </label>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </aside>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -758,6 +758,38 @@ body.light-mode .hero-title {
   text-align: center;
 }
 
+/* Drag and Drop Reordering */
+.drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  color: var(--muted);
+  opacity: 0.3;
+  margin-right: 4px;
+  transition: opacity 0.2s ease, color 0.2s ease;
+  user-select: none;
+}
+
+.sec-toggle:hover .drag-handle {
+  opacity: 0.7;
+}
+
+.drag-handle:hover {
+  color: var(--accent);
+  opacity: 1 !important;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}
+
+.sec-toggle.dragging {
+  opacity: 0.4;
+  border: 1px dashed var(--accent);
+  background: var(--surface2);
+}
+
 .toggle-switch {
   width: 36px;
   height: 20px;

--- a/src/utils/markdownUtils.js
+++ b/src/utils/markdownUtils.js
@@ -89,7 +89,7 @@ export function md2html(md) {
   return h;
 }
 
-export function generateMarkdown({ formData, sectionState, selectedTechs, selectedBadges, screenshots }) {
+export function generateMarkdown({ formData, sectionState, selectedTechs, selectedBadges, screenshots, sectionOrder }) {
   const {
     projName, tagline, ghUser: ghUserRaw, repoSlug: repoSlugRaw,
     description, demoUrl, features, prereqs, installCmds, envVars,
@@ -104,202 +104,221 @@ export function generateMarkdown({ formData, sectionState, selectedTechs, select
   const ghUser = ghUserRaw || authorGh || 'username';
   const repoSlug = repoSlugRaw || name.toLowerCase().replace(/\s+/g, '-');
   const on = (id) => sectionState[id];
+  const order = sectionOrder || [
+    'title', 'description', 'academic', 'features', 'techstack',
+    'installation', 'structure', 'screenshots', 'api', 'contributing',
+    'author', 'support'
+  ];
   let md = '';
 
-  if (on('title')) {
-    md += `# ${name}\n\n`;
-    if (tagline) md += `> **${tagline}**\n\n`;
-    const badges = [];
-    if (selectedBadges.has('license') && license !== 'none')
-      badges.push(`[![License](https://img.shields.io/badge/license-${encodeURIComponent(license)}-green.svg)](LICENSE)`);
-    if (selectedBadges.has('stars'))
-      badges.push(`[![Stars](https://img.shields.io/github/stars/${ghUser}/${repoSlug}?style=social)](https://github.com/${ghUser}/${repoSlug})`);
-    if (selectedBadges.has('forks'))
-      badges.push(`[![Forks](https://img.shields.io/github/forks/${ghUser}/${repoSlug}?style=social)](https://github.com/${ghUser}/${repoSlug}/fork)`);
-    if (selectedBadges.has('issues'))
-      badges.push(`[![Issues](https://img.shields.io/github/issues/${ghUser}/${repoSlug})](https://github.com/${ghUser}/${repoSlug}/issues)`);
-    if (selectedBadges.has('prs'))
-      badges.push(`[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/${ghUser}/${repoSlug}/pulls)`);
-    if (selectedBadges.has('build'))
-      badges.push(`![Build](https://img.shields.io/badge/build-passing-brightgreen)`);
-    if (selectedBadges.has('coverage'))
-      badges.push(`![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen)`);
-    if (selectedBadges.has('version'))
-      badges.push(`![Version](https://img.shields.io/badge/version-1.0.0-blue)`);
-    if (badges.length) md += badges.join(' ') + '\n\n';
-    md += '---\n\n';
-    md += '## 📋 Table of Contents\n\n';
-    if (on('description')) md += '- [Description](#-description)\n';
-    if (on('academic')) md += '- [Academic / Research Details](#academic--research-details)\n';
-    if (on('features')) md += '- [Features](#-features)\n';
-    if (on('techstack')) md += '- [Tech Stack](#-tech-stack)\n';
-    if (on('installation')) md += '- [Installation](#-installation)\n';
-    if (on('structure')) md += '- [Project Structure](#-project-structure)\n';
-    if (on('screenshots')) md += '- [Screenshots](#-screenshots)\n';
-    if (on('api')) md += '- [API Reference](#-api-reference)\n';
-    if (on('contributing')) md += '- [Contributing](#-contributing)\n';
-    if (on('author')) md += '- [License](#-license)\n- [Author](#-author)\n';
-    if (on('support')) md += '- [Support & Donation](#️-support--donation)\n';
-    md += '\n---\n\n';
-  }
+  const generators = {
+    title: () => {
+      let chunk = `# ${name}\n\n`;
+      if (tagline) chunk += `> **${tagline}**\n\n`;
+      const badges = [];
+      if (selectedBadges.has('license') && license !== 'none')
+        badges.push(`[![License](https://img.shields.io/badge/license-${encodeURIComponent(license)}-green.svg)](LICENSE)`);
+      if (selectedBadges.has('stars'))
+        badges.push(`[![Stars](https://img.shields.io/github/stars/${ghUser}/${repoSlug}?style=social)](https://github.com/${ghUser}/${repoSlug})`);
+      if (selectedBadges.has('forks'))
+        badges.push(`[![Forks](https://img.shields.io/github/forks/${ghUser}/${repoSlug}?style=social)](https://github.com/${ghUser}/${repoSlug}/fork)`);
+      if (selectedBadges.has('issues'))
+        badges.push(`[![Issues](https://img.shields.io/github/issues/${ghUser}/${repoSlug})](https://github.com/${ghUser}/${repoSlug}/issues)`);
+      if (selectedBadges.has('prs'))
+        badges.push(`[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/${ghUser}/${repoSlug}/pulls)`);
+      if (selectedBadges.has('build'))
+        badges.push(`![Build](https://img.shields.io/badge/build-passing-brightgreen)`);
+      if (selectedBadges.has('coverage'))
+        badges.push(`![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen)`);
+      if (selectedBadges.has('version'))
+        badges.push(`![Version](https://img.shields.io/badge/version-1.0.0-blue)`);
+      if (badges.length) chunk += badges.join(' ') + '\n\n';
 
-  if (on('description')) {
-    md += '## 📌 Description\n\n';
-    md += (description || '_Add a description of your project here._') + '\n\n';
-    if (demoUrl) md += `🔗 **Live Demo:** [${demoUrl}](${demoUrl})\n\n`;
-    md += '---\n\n';
-  }
-
-  if (on('academic')) {
-    const hasAcademicContent = abstractText || paperLink || datasetLink || methodology || bibtexCitation;
-    if (hasAcademicContent) {
-      md += '## Academic / Research Details\n\n';
+      chunk += '---\n\n';
+      chunk += '## 📋 Table of Contents\n\n';
+      order.forEach(secId => {
+        if (secId === 'title') return;
+        if (on(secId)) {
+          if (secId === 'description') chunk += '- [Description](#-description)\n';
+          else if (secId === 'academic') chunk += '- [Academic / Research Details](#academic--research-details)\n';
+          else if (secId === 'features') chunk += '- [Features](#-features)\n';
+          else if (secId === 'techstack') chunk += '- [Tech Stack](#-tech-stack)\n';
+          else if (secId === 'installation') chunk += '- [Installation](#-installation)\n';
+          else if (secId === 'structure') chunk += '- [Project Structure](#-project-structure)\n';
+          else if (secId === 'screenshots') chunk += '- [Screenshots](#-screenshots)\n';
+          else if (secId === 'api') chunk += '- [API Reference](#-api-reference)\n';
+          else if (secId === 'contributing') chunk += '- [Contributing](#-contributing)\n';
+          else if (secId === 'author') chunk += '- [License](#-license)\n- [Author](#-author)\n';
+          else if (secId === 'support') chunk += '- [Support & Donation](#️-support--donation)\n';
+        }
+      });
+      chunk += '\n---\n\n';
+      return chunk;
+    },
+    description: () => {
+      let chunk = '## 📌 Description\n\n';
+      chunk += (description || '_Add a description of your project here._') + '\n\n';
+      if (demoUrl) chunk += `🔗 **Live Demo:** [${demoUrl}](${demoUrl})\n\n`;
+      chunk += '---\n\n';
+      return chunk;
+    },
+    academic: () => {
+      const hasAcademicContent = abstractText || paperLink || datasetLink || methodology || bibtexCitation;
+      if (!hasAcademicContent) return '';
+      let chunk = '## Academic / Research Details\n\n';
       const academicBadges = [];
       if (paperLink) academicBadges.push(`[![Paper](https://img.shields.io/badge/Paper-Read%20Now-blue)](${paperLink})`);
       if (datasetLink) academicBadges.push(`[![Dataset](https://img.shields.io/badge/Dataset-Access-green)](${datasetLink})`);
-      if (academicBadges.length) md += academicBadges.join(' ') + '\n\n';
-      if (abstractText) md += `### Abstract\n\n${abstractText}\n\n`;
-      if (paperLink) md += `### Paper Link\n\n[${paperLink}](${paperLink})\n\n`;
-      if (datasetLink) md += `### Dataset Access\n\n[${datasetLink}](${datasetLink})\n\n`;
+      if (academicBadges.length) chunk += academicBadges.join(' ') + '\n\n';
+      if (abstractText) chunk += `### Abstract\n\n${abstractText}\n\n`;
+      if (paperLink) chunk += `### Paper Link\n\n[${paperLink}](${paperLink})\n\n`;
+      if (datasetLink) chunk += `### Dataset Access\n\n[${datasetLink}](${datasetLink})\n\n`;
       if (methodology) {
-        md += '### Methodology\n\n';
+        chunk += '### Methodology\n\n';
         methodology.split('\n').forEach(line => {
           const l = line.trimEnd();
-          if (l.trim().startsWith('###')) md += '\n' + l.trim() + '\n';
-          else if (l.trim()) md += (l.trim().startsWith('-') ? l : '- ' + l.trim()) + '\n';
+          if (l.trim().startsWith('###')) chunk += '\n' + l.trim() + '\n';
+          else if (l.trim()) chunk += (l.trim().startsWith('-') ? l : '- ' + l.trim()) + '\n';
         });
-        md += '\n';
+        chunk += '\n';
       }
-      if (bibtexCitation) md += `### Citation\n\n\`\`\`bibtex\n${bibtexCitation}\n\`\`\`\n\n`;
-      md += '---\n\n';
-    }
-  }
-
-  if (on('features') && features) {
-    md += '## ✨ Features\n\n';
-    features.split('\n').forEach(line => {
-      const l = line.trimEnd();
-      if (l.trim().startsWith('###')) md += '\n' + l.trim() + '\n';
-      else if (l.trim()) md += (l.trim().startsWith('-') ? l : '- ' + l.trim()) + '\n';
-    });
-    md += '\n---\n\n';
-  }
-
-  if (on('techstack')) {
-    const allTech = Array.from(selectedTechs);
-    if (customTech) customTech.split(',').forEach(t => { const tr = t.trim(); if (tr) allTech.push(tr); });
-    if (allTech.length) {
-      md += '## 🛠️ Tech Stack\n\n| Layer | Technology |\n|---|---|\n';
+      if (bibtexCitation) chunk += `### Citation\n\n\`\`\`bibtex\n${bibtexCitation}\n\`\`\`\n\n`;
+      chunk += '---\n\n';
+      return chunk;
+    },
+    features: () => {
+      if (!features) return '';
+      let chunk = '## ✨ Features\n\n';
+      features.split('\n').forEach(line => {
+        const l = line.trimEnd();
+        if (l.trim().startsWith('###')) chunk += '\n' + l.trim() + '\n';
+        else if (l.trim()) chunk += (l.trim().startsWith('-') ? l : '- ' + l.trim()) + '\n';
+      });
+      chunk += '\n---\n\n';
+      return chunk;
+    },
+    techstack: () => {
+      const allTech = Array.from(selectedTechs);
+      if (customTech) customTech.split(',').forEach(t => { const tr = t.trim(); if (tr) allTech.push(tr); });
+      if (!allTech.length) return '';
+      let chunk = '## 🛠️ Tech Stack\n\n| Layer | Technology |\n|---|---|\n';
       const front = allTech.filter(t => ['React','Vue','Next.js','TypeScript','JavaScript','Tailwind','HTML','CSS'].includes(t));
       const back = allTech.filter(t => ['Node.js','Express','Django','FastAPI','Flask','Spring','Go','Python','Rust','Java','C++'].includes(t));
       const db = allTech.filter(t => ['PostgreSQL','MySQL','MongoDB','SQLite','Redis'].includes(t));
       const infra = allTech.filter(t => ['Docker','Kubernetes','AWS','GCP','Azure','Nginx','Linux'].includes(t));
       const ml = allTech.filter(t => ['TensorFlow','PyTorch','GraphQL'].includes(t));
       const rest = allTech.filter(t => ![...front,...back,...db,...infra,...ml].includes(t));
-      if (front.length) md += `| Frontend | ${front.join(', ')} |\n`;
-      if (back.length) md += `| Backend  | ${back.join(', ')} |\n`;
-      if (db.length) md += `| Database | ${db.join(', ')} |\n`;
-      if (ml.length) md += `| AI / ML  | ${ml.join(', ')} |\n`;
-      if (infra.length) md += `| DevOps   | ${infra.join(', ')} |\n`;
-      if (rest.length) md += `| Other    | ${rest.join(', ')} |\n`;
-      md += '\n---\n\n';
-    }
-  }
-
-  if (on('installation')) {
-    md += '## 🚀 Installation\n\n';
-    if (prereqs) md += `**Prerequisites:** ${prereqs}\n\n`;
-    if (installCmds) {
-      md += '```bash\n' + installCmds + '\n```\n\n';
-    } else {
-      md += `\`\`\`bash\ngit clone https://github.com/${ghUser}/${repoSlug}.git\ncd ${repoSlug}\n\`\`\`\n\n`;
-    }
-    if (envVars) md += '**Environment Variables** — create a `.env` file:\n\n```env\n' + envVars + '\n```\n\n';
-    if (usageCmd) md += '## 💻 Usage\n\n```bash\n' + usageCmd + '\n```\n\n';
-    md += '---\n\n';
-  }
-
-  if (on('structure') && rawStructure.trim()) {
-    md += '## 📁 Project Structure\n\n```\n' + convertStructure(rawStructure, name) + '\n```\n\n---\n\n';
-  }
-
-  if (on('screenshots')) {
-    const hasContent = videoUrl || screenshots.length || imageUrls.trim();
-    if (hasContent) {
-      md += '## 🖼️ Screenshots\n\n';
-      if (videoUrl) md += `▶️ **Demo Video:** [Watch Here](${videoUrl})\n\n`;
+      if (front.length) chunk += `| Frontend | ${front.join(', ')} |\n`;
+      if (back.length) chunk += `| Backend  | ${back.join(', ')} |\n`;
+      if (db.length) chunk += `| Database | ${db.join(', ')} |\n`;
+      if (ml.length) chunk += `| AI / ML  | ${ml.join(', ')} |\n`;
+      if (infra.length) chunk += `| DevOps   | ${infra.join(', ')} |\n`;
+      if (rest.length) chunk += `| Other    | ${rest.join(', ')} |\n`;
+      chunk += '\n---\n\n';
+      return chunk;
+    },
+    installation: () => {
+      let chunk = '## 🚀 Installation\n\n';
+      if (prereqs) chunk += `**Prerequisites:** ${prereqs}\n\n`;
+      if (installCmds) {
+        chunk += '```bash\n' + installCmds + '\n```\n\n';
+      } else {
+        chunk += `\`\`\`bash\ngit clone https://github.com/${ghUser}/${repoSlug}.git\ncd ${repoSlug}\n\`\`\`\n\n`;
+      }
+      if (envVars) chunk += '**Environment Variables** — create a `.env` file:\n\n```env\n' + envVars + '\n```\n\n';
+      if (usageCmd) chunk += '## 💻 Usage\n\n```bash\n' + usageCmd + '\n```\n\n';
+      chunk += '---\n\n';
+      return chunk;
+    },
+    structure: () => {
+      if (!rawStructure.trim()) return '';
+      return '## 📁 Project Structure\n\n```\n' + convertStructure(rawStructure, name) + '\n```\n\n---\n\n';
+    },
+    screenshots: () => {
+      const hasContent = videoUrl || screenshots.length || imageUrls.trim();
+      if (!hasContent) return '';
+      let chunk = '## 🖼️ Screenshots\n\n';
+      if (videoUrl) chunk += `▶️ **Demo Video:** [Watch Here](${videoUrl})\n\n`;
       screenshots.forEach(ss => {
         const label = ss.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ');
-        md += `### ${label}\n\n![${label}](${ss.dataUrl})\n\n`;
+        chunk += `### ${label}\n\n![${label}](${ss.dataUrl})\n\n`;
       });
       if (imageUrls.trim()) {
         imageUrls.split('\n').filter(l => l.trim()).forEach(line => {
           const parts = line.split('|').map(p => p.trim());
-          if (parts.length >= 2) md += `### ${parts[0]}\n\n![${parts[0]}](${parts[1]})\n\n`;
-          else if (parts[0]) md += `![Screenshot](${parts[0]})\n\n`;
+          if (parts.length >= 2) chunk += `### ${parts[0]}\n\n![${parts[0]}](${parts[1]})\n\n`;
+          else if (parts[0]) chunk += `![Screenshot](${parts[0]})\n\n`;
         });
       }
-      md += '---\n\n';
-    }
-  }
-
-  if (on('api') && apiDocs.trim()) {
-    md += '## ⚡ API Reference\n\n';
-    if (apiBase) md += `**Base URL:** \`${apiBase}\`\n\n`;
-    md += '| Method | Endpoint | Description |\n|--------|----------|-------------|\n';
-    apiDocs.split('\n').filter(l => l.trim()).forEach(line => {
-      const parts = line.split('|').map(p => p.trim());
-      if (parts.length >= 2) {
-        const ep = parts[0].split(' ');
-        md += `| \`${ep[0]}\` | \`${ep.slice(1).join(' ')}\` | ${parts[1]} |\n`;
-      }
-    });
-    md += '\n---\n\n';
-  }
-
-  if (on('contributing')) {
-    md += '## 🤝 Contributing\n\nContributions are always welcome!\n\n';
-    md += '1. Fork the repository\n';
-    md += '2. Create your branch: `git checkout -b feature/amazing-feature`\n';
-    md += '3. Commit your changes: `git commit -m "Add amazing feature"`\n';
-    md += '4. Push to the branch: `git push origin feature/amazing-feature`\n';
-    md += '5. Open a Pull Request\n\n';
-    if (contribNotes) md += contribNotes + '\n\n';
-    md += '---\n\n';
-  }
-
-  if (on('author')) {
-    if (license !== 'none')
-      md += `## 📄 License\n\nThis project is licensed under the **[${license} License](LICENSE)**.\n\n---\n\n`;
-    md += '## 👤 Author\n\n';
-    const displayName = authorName || authorGh || ghUser;
-    md += `**${displayName}**\n\n`;
-    if (authorGh) md += `- 🐙 GitHub: [@${authorGh}](https://github.com/${authorGh})\n`;
-    if (authorEmail) md += `- 📧 Email: [${authorEmail}](mailto:${authorEmail})\n`;
-    if (authorLinkedin) md += `- 💼 LinkedIn: [${displayName}](${authorLinkedin})\n`;
-    if (authorWebsite) md += `- 🌐 Website: [${authorWebsite}](${authorWebsite})\n`;
-    md += '\n---\n\n';
-    md += `> Made with ❤️ by [${displayName}](https://github.com/${authorGh || ghUser})\n`;
-  }
-
-  if (on('support')) {
-    const hasSupportUrls = supportBmac || supportKofi || supportPatreon || supportGhSponsors;
-    if (supportMsg || hasSupportUrls) {
-      md += '## ❤️ Support & Donation\n\n';
+      chunk += '---\n\n';
+      return chunk;
+    },
+    api: () => {
+      if (!apiDocs.trim()) return '';
+      let chunk = '## ⚡ API Reference\n\n';
+      if (apiBase) chunk += `**Base URL:** \`${apiBase}\`\n\n`;
+      chunk += '| Method | Endpoint | Description |\n|--------|----------|-------------|\n';
+      apiDocs.split('\n').filter(l => l.trim()).forEach(line => {
+        const parts = line.split('|').map(p => p.trim());
+        if (parts.length >= 2) {
+          const ep = parts[0].split(' ');
+          chunk += `| \`${ep[0]}\` | \`${ep.slice(1).join(' ')}\` | ${parts[1]} |\n`;
+        }
+      });
+      chunk += '\n---\n\n';
+      return chunk;
+    },
+    contributing: () => {
+      let chunk = '## 🤝 Contributing\n\nContributions are always welcome!\n\n';
+      chunk += '1. Fork the repository\n';
+      chunk += '2. Create your branch: `git checkout -b feature/amazing-feature`\n';
+      chunk += '3. Commit your changes: `git commit -m "Add amazing feature"`\n';
+      chunk += '4. Push to the branch: `git push origin feature/amazing-feature`\n';
+      chunk += '5. Open a Pull Request\n\n';
+      if (contribNotes) chunk += contribNotes + '\n\n';
+      chunk += '---\n\n';
+      return chunk;
+    },
+    author: () => {
+      let chunk = '';
+      if (license !== 'none')
+        chunk += `## 📄 License\n\nThis project is licensed under the **[${license} License](LICENSE)**.\n\n---\n\n`;
+      chunk += '## 👤 Author\n\n';
+      const displayName = authorName || authorGh || ghUser;
+      chunk += `**${displayName}**\n\n`;
+      if (authorGh) chunk += `- 🐙 GitHub: [@${authorGh}](https://github.com/${authorGh})\n`;
+      if (authorEmail) chunk += `- 📧 Email: [${authorEmail}](mailto:${authorEmail})\n`;
+      if (authorLinkedin) chunk += `- 💼 LinkedIn: [${displayName}](${authorLinkedin})\n`;
+      if (authorWebsite) chunk += `- 🌐 Website: [${authorWebsite}](${authorWebsite})\n`;
+      chunk += '\n---\n\n';
+      chunk += `> Made with ❤️ by [${displayName}](https://github.com/${authorGh || ghUser})\n`;
+      return chunk;
+    },
+    support: () => {
+      const hasSupportUrls = supportBmac || supportKofi || supportPatreon || supportGhSponsors;
+      if (!supportMsg && !hasSupportUrls) return '';
+      let chunk = '## ❤️ Support & Donation\n\n';
       if (supportMsg) {
-        md += supportMsg + '\n\n';
+        chunk += supportMsg + '\n\n';
       } else {
-        md += 'If you find this project helpful, please consider supporting its development:\n\n';
+        chunk += 'If you find this project helpful, please consider supporting its development:\n\n';
       }
       const supportLinks = [];
       if (supportBmac) supportLinks.push(`[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://www.buymeacoffee.com/${supportBmac})`);
       if (supportKofi) supportLinks.push(`[![Ko-fi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/${supportKofi})`);
       if (supportPatreon) supportLinks.push(`[![Patreon](https://img.shields.io/badge/Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white)](https://patreon.com/${supportPatreon})`);
       if (supportGhSponsors) supportLinks.push(`[![GitHub Sponsors](https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/${supportGhSponsors})`);
-      if (supportLinks.length) md += supportLinks.join(' ') + '\n\n';
-      md += '---\n\n';
+      if (supportLinks.length) chunk += supportLinks.join(' ') + '\n\n';
+      chunk += '---\n\n';
+      return chunk;
     }
-  }
+  };
+
+  order.forEach(secId => {
+    if (on(secId) && generators[secId]) {
+      md += generators[secId]();
+    }
+  });
 
   return md;
 }


### PR DESCRIPTION
Closes #163 

Title:  Add README section reordering functionality using drag and drop

Overview
Adds a drag-and-drop feature to the sidebar so users can dynamically customize the structure of their generated README before exporting.

Key Improvements
Drag-and-Drop Interaction: Added a sleek grip handle (⋮⋮) and native drag-and-drop support to sidebar sections.
Dynamic Markdown Output: Refactored the compiler (markdownUtils.js) to generate sections and the Table of Contents in the user's custom order.
Persistence: Custom section orders are automatically saved to localStorage and restored on page load.
Visual Styling: Added drag feedback (grab cursors, transparency cues, and borders) to improve usability.




